### PR TITLE
namespace support for maintainers

### DIFF
--- a/MAINTAINERS-EXTRAS.txt
+++ b/MAINTAINERS-EXTRAS.txt
@@ -38,27 +38,10 @@ cloud/centurylink/clc_modify_server.py: clc-runner
 cloud/centurylink/clc_publicip.py: clc-runner
 cloud/centurylink/clc_server.py: clc-runner
 cloud/centurylink/clc_server_snapshot.py: clc-runner
-cloud/cloudstack/cs_account.py: resmo
-cloud/cloudstack/cs_affinitygroup.py: resmo
-cloud/cloudstack/cs_domain.py: resmo
-cloud/cloudstack/cs_facts.py: resmo
-cloud/cloudstack/cs_firewall.py: resmo
-cloud/cloudstack/cs_instance.py: resmo
-cloud/cloudstack/cs_instancegroup.py: resmo
+cloud/cloudstack/: resmo
 cloud/cloudstack/cs_ip_address.py: dazworrall
-cloud/cloudstack/cs_iso.py: resmo
-cloud/cloudstack/cs_loadbalancer_rule.py: dazworrall resmo
-cloud/cloudstack/cs_loadbalancer_rule_member.py: dazworrall resmo
-cloud/cloudstack/cs_network.py: resmo
-cloud/cloudstack/cs_portforward.py: resmo
-cloud/cloudstack/cs_project.py: resmo
-cloud/cloudstack/cs_securitygroup.py: resmo
-cloud/cloudstack/cs_securitygroup_rule.py: resmo
-cloud/cloudstack/cs_sshkeypair.py: resmo
-cloud/cloudstack/cs_staticnat.py: resmo
-cloud/cloudstack/cs_template.py: resmo
-cloud/cloudstack/cs_user.py: resmo
-cloud/cloudstack/cs_vmsnapshot.py: resmo
+cloud/cloudstack/cs_loadbalancer_rule.py: dazworrall
+cloud/cloudstack/cs_loadbalancer_rule_member.py: dazworrall
 cloud/google/gce_img.py: tanpeter
 cloud/google/gce_tag.py: dohoangkhiemgmail.com
 cloud/lxc/lxc_container.py: cloudnull

--- a/prbot.py
+++ b/prbot.py
@@ -173,19 +173,20 @@ def triage(urlstring):
     # Look up the files in the local DB to see who maintains them.
     # (Warn if there's more than one; we can't handle that case yet.)
     #----------------------------------------------------------------------------
-    maintainer_found = ''
+    pr_maintainers_list = []
     if ghrepo == "core":
         f = open('MAINTAINERS-CORE.txt')
     elif ghrepo == "extras":
         f = open('MAINTAINERS-EXTRAS.txt')
     for line in f:
-        if pr_filename in line:
-            pr_maintainers = (line.split(': ')[-1]).rstrip()
-            maintainer_found = 'True'
-            break
+        owner_space = (line.split(': ')[0]).strip()
+        if owner_space in pr_filename:
+            maintainers_string = (line.split(': ')[-1]).strip()
+            for maintainer in maintainers_string.split(' '):
+                pr_maintainers_list.append(maintainer)
     f.close()
-    if not maintainer_found:
-        pr_maintainers = ''
+
+    pr_maintainers = ' '.join(pr_maintainers_list)
 
     #----------------------------------------------------------------------------
     # Pull the list of labels on this PR and shove them into pr_labels.


### PR DESCRIPTION
e.g. cloud/cloudstack/ is resmo's maintainer namespace

I made the commit small and self explaining, only implementing namespacing. Tested it and worked for me. Thanks @gregdek 

```
1591 --- [2.1] cloudstack: new module cs_zone
  Labels:  [u'cloud', u'new_plugin', u'owner_pr']
  Submitter:  resmo
  Maintainer(s): resmo
  Filename(s):  cloud/cloudstack/cs_zone.py
 
 
RECOMMENDED ACTIONS for  https://github.com/ansible/ansible-modules-extras/pull/1591
   newlabel: shipit
   newlabel: owner_pr
   boilerplate: shipit_owner_pr
```

