### PR TITLE
new triage

### DIFF
--- a/templates/backport.j2
+++ b/templates/backport.j2
@@ -1,0 +1,1 @@
+Thanks @{{ submitter }}. All backport requests must be reviewed by the core team, and this can take time. We appreciate your patience.

--- a/templates/community_review_existing.j2
+++ b/templates/community_review_existing.j2
@@ -1,0 +1,1 @@
+Thanks @{{ submitter }}. To the current maintainers, @{{ maintainer|join(', @') }} please review according to guidelines (http://docs.ansible.com/ansible/developing_modules.html#module-checklist) and comment with text 'shipit' or 'needs_revision' as appropriate.

--- a/templates/community_review_new.j2
+++ b/templates/community_review_new.j2
@@ -1,0 +1,1 @@
+Thanks @{{ submitter }} for this new module. When this module receives 'shipit' comments from two community members and any 'needs_revision' comments have been resolved, we will mark for inclusion.

--- a/templates/core_review_existing.j2
+++ b/templates/core_review_existing.j2
@@ -1,0 +1,1 @@
+Thanks @{{ submitter }} for this PR. This module is maintained by the Ansible core team, so it can take a while for patches to be reviewed. Thanks for your patience.

--- a/templates/maintainer_first_warning.j2
+++ b/templates/maintainer_first_warning.j2
@@ -1,0 +1,1 @@
+@{{ maintainer|join(', @') }} This change is still pending your review; do you have time to take a look and comment? Please comment with text 'shipit' or 'needs_revision' as appropriate.

--- a/templates/maintainer_second_warning.j2
+++ b/templates/maintainer_second_warning.j2
@@ -1,0 +1,1 @@
+@{{ maintainer|join(', @') }} still waiting on your review. Please comment with text 'shipit' or 'needs_revision' as appropriate. If we don't hear from you within 14 days, we will start to look for additional maintainers for this module.

--- a/templates/needs_rebase.j2
+++ b/templates/needs_rebase.j2
@@ -1,0 +1,1 @@
+Thanks @{{ submitter }} for this PR. Unfortunately, it is not mergeable in its current state due to merge conflicts. Please rebase your PR. When you are done, please comment with text 'ready_for_review' and we will put this PR back into review.

--- a/templates/needs_revision.j2
+++ b/templates/needs_revision.j2
@@ -1,0 +1,1 @@
+Thanks @{{ submitter }} for this PR. A maintainer of this module has asked for revisions to this PR. Please make the suggested revisions. When you are done, please comment with text 'ready_for_review' and we will put this PR back into review.

--- a/templates/shipit.j2
+++ b/templates/shipit.j2
@@ -1,0 +1,1 @@
+Thanks again to @{{ submitter }} for this PR, and thanks @{{ maintainer|join(', @') }} for reviewing. Marking for inclusion.

--- a/templates/shipit_owner_pr.j2
+++ b/templates/shipit_owner_pr.j2
@@ -1,0 +1,1 @@
+Thanks @{{ submitter }}. Since you are a maintainer of this module, we are marking this PR for inclusion.

--- a/templates/submitter_first_warning.j2
+++ b/templates/submitter_first_warning.j2
@@ -1,0 +1,1 @@
+@{{ submitter }} A friendly reminder: this pull request has been marked as needing your action. If you still believe that this PR applies, and you intend to address the issues with this PR, just let us know in the PR itself and we will keep it open pending your changes.

--- a/templates/submitter_second_warning.j2
+++ b/templates/submitter_second_warning.j2
@@ -1,0 +1,1 @@
+@{{ submitter }} Another friendly reminder: this pull request has been marked as needing your action. If you still believe that this PR applies, and you intend to address the issues with this PR, just let us know in the PR itself and we will keep it open. If we don't hear from you within another 14 days, we will close this pull request.

--- a/triage.py
+++ b/triage.py
@@ -1,0 +1,638 @@
+#!/usr/bin/python
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible. If not, see <http://www.gnu.org/licenses/>.
+
+from __future__ import print_function
+
+import argparse
+import os
+import sys
+from datetime import datetime
+
+from github import Github
+
+from jinja2 import Environment, FileSystemLoader
+
+loader = FileSystemLoader(os.path.join(os.path.dirname(__file__), 'templates'))
+environment = Environment(loader=loader, trim_blocks=True)
+
+# A dict of alias labels. It is used for coupling a template (comment) with a
+# label.
+ALIAS_LABELS = {
+    'core_review': [
+        'core_review_existing'
+    ],
+    'community_review': [
+        'community_review_existing',
+        'community_review_new'
+    ],
+    'shipit': [
+        'shipit_owner_pr'
+    ],
+}
+
+MAINTAINERS_FILES = {
+    'core': "MAINTAINERS-CORE.txt",
+    'extras': "MAINTAINERS-EXTRAS.txt",
+}
+
+# modules having files starting like the key, will get the value label
+MODULE_NAMESPACE_LABELS = {
+    'cloud': "cloud",
+    'windows': "windows",
+    'network': "networking"
+}
+
+# We don't remove any of these labels unless forced
+SKIP_UNLABELING_FOR_LABELS = [
+    "shipit",
+    "needs_revision",
+    "needs_info",
+]
+
+# Static labels, manually added
+IGNORE_LABELS = [
+    "feature_pull_request",
+    "bugfix_pull_request",
+    "in progress"
+]
+
+# We warn for human interaction
+MANUAL_INTERACTION_LABELS = [
+    "needs_revision",
+    "needs_info",
+]
+
+BOTLIST = [
+    'gregdek',
+    'robynbergeron'
+]
+
+
+class PullRequest:
+
+    def __init__(self, repo, pr_number=None, pr=None):
+        self.repo = repo
+
+        if not pr:
+            self.instance = self.repo.get_pull(pr_number)
+        else:
+            self.instance = pr
+
+        self.pr_number = self.instance.number
+
+        self.issue = None
+        self.pr_filenames = []
+        self.current_pr_labels = []
+        self.desired_pr_labels = []
+
+        # we have a few labels we don't touch unless forced
+        self.unlabeling_forced = False
+
+        self.current_comments = []
+        self.desired_comments = []
+
+    def get_pr_filenames(self):
+        """Returns all files related to this PR"""
+        if not self.pr_filenames:
+            for pr_file in self.instance.get_files():
+                self.pr_filenames.append(pr_file.filename)
+        return self.pr_filenames
+
+    def get_pr_submitter(self):
+        """Returns the PR submitter"""
+        return self.instance.user.login
+
+    def pr_contains_new_file(self):
+        """Return True if PR contains new files"""
+        for pr_file in self.instance.get_files():
+            if pr_file.status == "added":
+                return True
+        return False
+
+    def is_labeled_for_interaction(self):
+        """Returns True if PR is labeled for interaction"""
+        for current_pr_label in self.get_current_labels():
+            if current_pr_label in MANUAL_INTERACTION_LABELS:
+                return True
+        return False
+
+    def is_mergeable(self):
+        """Return True if PR is mergeable"""
+        return self.instance.mergeable_state != "dirty"
+
+    def get_base_ref(self):
+        """Returns base ref of PR"""
+        return self.instance.base.ref
+
+    def get_issue(self):
+        """Gets the issue from the GitHub API"""
+        if not self.issue:
+            self.issue = self.repo.get_issue(self.pr_number)
+        return self.issue
+
+    def get_current_labels(self):
+        """Pull the list of labels on this PR and shove them into
+        pr_labels.
+        """
+        if not self.current_pr_labels:
+            labels = self.get_issue().labels
+            for label in labels:
+                self.current_pr_labels.append(label.name)
+        return self.current_pr_labels
+
+    def get_comments(self):
+        """Returns all current comments of the PR"""
+        if not self.current_comments:
+            self.current_comments = self.instance.get_issue_comments().reversed
+        return self.current_comments
+
+    def add_desired_label(self, name=None):
+        """Adds a label to the desired labels list"""
+        if name and name not in self.desired_pr_labels:
+            self.desired_pr_labels.append(name)
+
+    def add_desired_comment(self, boilerplate=None):
+        """Adds a boilerplate key to the desired comments list"""
+        if boilerplate and boilerplate not in self.desired_comments:
+            self.desired_comments.append(boilerplate)
+
+    def add_label(self, label=None):
+        """Adds a label to the PR using the GitHub API"""
+        self.get_issue().add_to_labels(label)
+
+    def remove_label(self, label=None):
+        """Removes a label from the PR using the GitHub API"""
+        self.get_issue().remove_from_labels(label)
+
+    def add_comment(self, comment=None):
+        """ Adds a comment to the PR using the GitHub API"""
+        self.get_issue().create_comment(comment)
+
+
+class Triage:
+    def __init__(self, verbose=None, github_user=None, github_pass=None,
+                 github_token=None, github_repo=None, pr_number=None,
+                 start_at_pr=None, always_pause=False, force=False):
+        self.verbose = verbose
+        self.github_user = github_user
+        self.github_pass = github_pass
+        self.github_token = github_token
+        self.github_repo = github_repo
+        self.pr_number = pr_number
+        self.start_at_pr = start_at_pr
+        self.always_pause = always_pause
+        self.force = force
+
+        self.pull_request = None
+        self.maintainers = {}
+        self.module_maintainers = []
+        self.actions = {
+            'newlabel': [],
+            'unlabel':  [],
+            'comments': [],
+        }
+
+    def _connect(self):
+        """Connects to GitHub's API"""
+        return Github(login_or_token=self.github_token or self.github_user,
+                      password=self.github_pass)
+
+    def _get_maintainers(self):
+        """Reads all known maintainers from files and their owner namespace"""
+        if not self.maintainers:
+            f = open(MAINTAINERS_FILES[self.github_repo])
+            for line in f:
+                owner_space = (line.split(': ')[0]).strip()
+                maintainers_string = (line.split(': ')[-1]).strip()
+                self.maintainers[owner_space] = maintainers_string.split(' ')
+            f.close()
+        return self.maintainers
+
+    def debug(self, msg=""):
+        """Prints debug message if verbosity is given"""
+        if self.verbose:
+            print("Debug: " + msg)
+
+    def get_module_maintainers(self):
+        """Returns the dict of maintainers using the key as owner namespace"""
+        if self.module_maintainers:
+            return self.module_maintainers
+
+        for owner_space, maintainers in self._get_maintainers().iteritems():
+            for filename in self.pull_request.get_pr_filenames():
+                if owner_space in filename:
+                    for maintainer in maintainers:
+                        if maintainer not in self.module_maintainers:
+                            self.module_maintainers.extend(maintainers)
+        return self.module_maintainers
+
+    def add_desired_labels_for_not_mergeable(self):
+        """Adds labels for not mergeable conditions"""
+        self.pull_request.unlabeling_forced = True
+        self.pull_request.add_desired_label(name="needs_rebase")
+
+    def add_desired_labels_by_namespace(self):
+        """Adds labels regarding module namespaces"""
+        for pr_filename in self.pull_request.get_pr_filenames():
+            namespace = pr_filename.split('/')[0]
+            for key, value in MODULE_NAMESPACE_LABELS.iteritems():
+                if key == namespace:
+                    self.pull_request.add_desired_label(value)
+
+    def add_desired_labels_by_gitref(self):
+        """Adds labels regarding gitref"""
+        if "stable" in self.pull_request.get_base_ref():
+            self.debug(msg="backport requested")
+            self.pull_request.add_desired_label(name="core_review")
+            self.pull_request.add_desired_label(name="backport")
+
+    def add_desired_labels_by_maintainers(self):
+        """Adds labels regarding maintainer infos"""
+        module_maintainers = self.get_module_maintainers()
+        pr_contains_new_file = self.pull_request.pr_contains_new_file()
+
+        if pr_contains_new_file:
+            self.debug(msg="plugin is new")
+            self.pull_request.add_desired_label(name="new_plugin")
+
+        if "ansible" in module_maintainers:
+            self.debug(msg="ansible in module maintainers")
+            self.pull_request.add_desired_label(name="core_review_existing")
+            return
+
+        if "needs_revision" in self.pull_request.get_current_labels():
+            self.debug(msg="needs revision labeled, skipping maintainer")
+            return
+
+        if self.pull_request.get_pr_submitter() in module_maintainers:
+            self.debug(msg="plugin by owner, shipit as owner_pr")
+            self.pull_request.add_desired_label(name="owner_pr")
+            self.pull_request.add_desired_label(name="shipit_owner_pr")
+            return
+
+        if "shipit" in self.pull_request.get_current_labels():
+            self.debug(msg="shipit labeled, skipping maintainer")
+            return
+
+        if not module_maintainers and pr_contains_new_file:
+            self.debug(msg="New plugin, no module maintainer yet")
+            self.pull_request.add_desired_label(name="community_review_new")
+        else:
+            self.debug(msg="existing plugin modified, module maintainer "
+                           "should review")
+            self.pull_request.add_desired_label(
+                name="community_review_existing"
+            )
+
+    def process_comments(self):
+        """ Processes PR comments for matching criteria for adding labels"""
+        module_maintainers = self.get_module_maintainers()
+        comments = self.pull_request.get_comments()
+
+        self.debug(msg="--- START Processing Comments:")
+
+        for comment in comments:
+
+            # Is the last useful comment from a bot user?  Then we've got a
+            # potential timeout case. Let's explore!
+            if comment.user.login in BOTLIST:
+
+                self.debug(msg="%s is in botlist: " % comment.user.login)
+
+                today = datetime.today()
+                time_delta = today - comment.created_at
+                comment_days_old = time_delta.days
+
+                self.debug(msg="Days since last bot comment: %s" %
+                           comment_days_old)
+
+                if comment_days_old > 14:
+                    pr_labels = self.pull_request.desired_pr_labels
+
+                    if "core_review" in pr_labels:
+                        self.debug(msg="has core_review")
+                        break
+
+                    if "pending" not in comment.body:
+                        if self.pull_request.is_labeled_for_interaction():
+                            self.pull_request.add_desired_comment(
+                                boilerplate="submitter_first_warning"
+                            )
+                            self.debug(msg="submitter_first_warning")
+                            break
+                        if ("community_review" in pr_labels and not
+                                self.pull_request.pr_contains_new_file()):
+                            self.debug(msg="maintainer_first_warning")
+                            self.pull_request.add_desired_comment(
+                                boilerplate="maintainer_first_warning"
+                            )
+                            break
+
+                    # pending in comment.body
+                    else:
+                        if self.pull_request.is_labeled_for_interaction():
+                            self.debug(msg="submitter_second_warning")
+                            self.pull_request.add_desired_comment(
+                                boilerplate="submitter_second_warning"
+                            )
+                            self.pull_request.add_desired_label(
+                                name="pending_action"
+                            )
+                            break
+                        if ("community_review" in pr_labels and
+                                "new_plugin" not in pr_labels):
+                            self.debug(msg="maintainer_second_warning")
+                            self.pull_request.add_desired_comment(
+                                boilerplate="maintainer_second_warning"
+                            )
+                            self.pull_request.add_desired_label(
+                                name="pending_action"
+                            )
+                            break
+                self.debug(msg="STATUS: no useful state change since last pass"
+                           "( %s )" % comment.user.login)
+                break
+
+            if comment.user.login in module_maintainers:
+                self.debug(msg="%s is module maintainer commented on %s." %
+                           (comment.user.login, comment.created_at))
+
+                if ("shipit" in comment.body or "+1" in comment.body
+                    or "LGTM" in comment.body):
+                    self.debug(msg="...said shipit!")
+                    self.pull_request.unlabeling_forced = True
+                    self.pull_request.add_desired_label(name="shipit")
+                    self.pull_request.add_desired_comment(
+                        boilerplate="shipit"
+                    )
+                    break
+
+                elif "needs_revision" in comment.body:
+                    self.debug(msg="...said needs_revision!")
+                    self.pull_request.unlabeling_forced = True
+                    self.pull_request.add_desired_label(name="needs_revision")
+                    break
+
+            if comment.user.login == self.pull_request.get_pr_submitter():
+                self.debug(msg="%s is PR submitter commented on %s." %
+                           (comment.user.login, comment.created_at))
+                if "ready_for_review" in comment.body:
+                    self.debug(msg="...ready for review!")
+                    self.pull_request.unlabeling_forced = True
+                    if "ansible" in module_maintainers:
+                        self.debug(msg="core does the review!")
+                        self.pull_request.add_desired_label(
+                            name="core_review_existing"
+                        )
+                    elif not module_maintainers:
+                        self.debug(msg="community does the review!")
+                        self.pull_request.add_desired_label(
+                            name="community_review_new"
+                        )
+                    else:
+                        self.debug(msg="community does the review but has "
+                                   "maintainer")
+                        self.pull_request.add_desired_label(
+                            name="community_review_existing"
+                        )
+                    break
+        self.debug(msg="--- END Processing Comments")
+
+    def resolve_desired_pr_labels(self, desired_pr_label):
+        """Resolves boilerplate the key labels to labels using an
+        alias dict
+        """
+        for resolved_desired_pr_label, aliases in ALIAS_LABELS.iteritems():
+            if desired_pr_label in aliases:
+                return resolved_desired_pr_label
+        return desired_pr_label
+
+    def render_comment(self, boilerplate=None):
+        """Renders templates into comments using the boilerplate as filename"""
+        maintainers = self.module_maintainers
+        if not maintainers:
+            maintainers = ['ansible/core']
+
+        submitter = self.pull_request.get_pr_submitter()
+
+        template = environment.get_template('%s.j2' % boilerplate)
+        comment = template.render(maintainer=maintainers, submitter=submitter)
+        return comment
+
+    def create_actions(self):
+        """Creates actions from the desired label, unlabel and comment actions
+        lists"""
+
+        # create new label and comments action
+        resolved_desired_pr_labels = []
+        for desired_pr_label in self.pull_request.desired_pr_labels:
+
+            # Most of the comments are only going to be added if we also add a
+            # new label. So they are coupled. That is why we use the
+            # boilerplate dict key as label and use an alias table containing
+            # the real labels. This allows us to either use a real new label
+            # without a comment or an label coupled with a comment. We check
+            # if the label is a boilerplate dict key and get the real label
+            # back or alternatively the label we gave as input
+            # e.g. label: community_review_existing -> community_review
+            # e.g. label: community_review -> community_review
+            resolved_desired_pr_label = self.resolve_desired_pr_labels(
+                desired_pr_label
+            )
+
+            # If we didn't get back the same, it means we must also add a
+            # comment for this label
+            if desired_pr_label != resolved_desired_pr_label:
+
+                # we cache for later use in unlabeling actions
+                resolved_desired_pr_labels.append(resolved_desired_pr_label)
+
+                # We only add actions (newlabel, comments) if the label is
+                # not already set
+                if (resolved_desired_pr_label not in
+                        self.pull_request.get_current_labels()):
+                    # Use the previous label as key for the boilerplate dict
+                    self.pull_request.add_desired_comment(desired_pr_label)
+                    self.actions['newlabel'].append(resolved_desired_pr_label)
+
+            # it is a real label, no comment needs to be added
+            else:
+                resolved_desired_pr_labels.append(desired_pr_label)
+                if (desired_pr_label not in
+                        self.pull_request.get_current_labels()):
+                    self.actions['newlabel'].append(desired_pr_label)
+
+        # unlabel action
+        for current_pr_label in self.pull_request.get_current_labels():
+
+            # some labels we just ignore
+            if current_pr_label in IGNORE_LABELS:
+                continue
+
+            # some of them we ignore unless forced
+            if (not self.pull_request.unlabeling_forced and
+                    current_pr_label in SKIP_UNLABELING_FOR_LABELS):
+                continue
+
+            # now check if we need to unlabel
+            if current_pr_label not in resolved_desired_pr_labels:
+                self.actions['unlabel'].append(current_pr_label)
+
+        for boilerplate in self.pull_request.desired_comments:
+            comment = self.render_comment(boilerplate=boilerplate)
+            self.debug(msg=comment)
+            self.actions['comments'].append(comment)
+
+    def process(self):
+        """Processes the PR"""
+        # clear all actions
+        self.actions = {
+            'newlabel': [],
+            'unlabel':  [],
+            'comments': [],
+        }
+        # clear module maintainers
+        self.module_maintainers = []
+        # print some general infos about the PR to be processed
+        print("\nPR #%s: %s" % (self.pull_request.pr_number,
+                                self.pull_request.instance.title))
+        print("Created at %s" % self.pull_request.instance.created_at)
+        print("Updated at %s" % self.pull_request.instance.updated_at)
+
+        # add desired labels
+        if self.pull_request.is_mergeable():
+            self.debug(msg="PR is mergeable")
+            self.add_desired_labels_by_namespace()
+            self.add_desired_labels_by_gitref()
+            self.add_desired_labels_by_maintainers()
+            # process comments after labels
+            self.process_comments()
+        else:
+            self.debug(msg="PR is not mergeable")
+            self.add_desired_labels_for_not_mergeable()
+
+        self.create_actions()
+
+        # Print the things we processed
+        print("Submitter: %s" % self.pull_request.get_pr_submitter())
+        print("Maintainers: %s" % ', '.join(self.get_module_maintainers()))
+        print("Current Labels: %s" %
+              ', '.join(self.pull_request.current_pr_labels))
+        print("Actions: %s" % self.actions)
+
+        if (self.actions['newlabel'] or self.actions['unlabel'] or
+                self.actions['comments']):
+            if self.force:
+                print("Running actions non-interactive as you forced.")
+                self.execute_actions()
+                return
+            cont = raw_input("Take recommended actions (y/N/a)? ")
+            if cont in ('a', 'A'):
+                sys.exit(0)
+            if cont in ('Y', 'y'):
+                self.execute_actions()
+        elif self.always_pause:
+            print("Skipping, but pause.")
+            cont = raw_input("Continue (Y/n/a)? ")
+            if cont in ('a', 'A', 'n', 'N'):
+                sys.exit(0)
+        else:
+            print("Skipping.")
+
+    def execute_actions(self):
+        """Turns the actions into API calls"""
+        for unlabel in self.actions['unlabel']:
+            self.debug(msg="API Call unlabel: " + unlabel)
+            self.pull_request.remove_label(label=unlabel)
+        for newlabel in self.actions['newlabel']:
+            self.debug(msg="API Call newlabel: " + newlabel)
+            self.pull_request.add_label(label=newlabel)
+        for comment in self.actions['comments']:
+            self.debug(msg="API Call comment: " + comment)
+            self.pull_request.add_comment(comment=comment)
+
+    def run(self):
+        """Starts a triage run"""
+        repo = self._connect().get_repo("ansible/ansible-modules-%s" %
+                                        self.github_repo)
+
+        if self.pr_number:
+            self.pull_request = PullRequest(repo=repo,
+                                            pr_number=self.pr_number)
+            self.process()
+        else:
+            pulls = repo.get_pulls()
+            for pull in pulls:
+                if self.start_at_pr and pull.number > self.start_at_pr:
+                    continue
+                self.pull_request = PullRequest(repo=repo, pr=pull)
+                self.process()
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Triage various PR queues "
+                                                 "for Ansible. (NOTE: only "
+                                                 "useful if you have commit "
+                                                 "access to the repo in "
+                                                 "question.)")
+    parser.add_argument("repo", type=str, choices=['core', 'extras'],
+                        help="Repo to be triaged")
+    parser.add_argument("--gh-user", "-u", type=str,
+                        help="Github username or token of triager")
+    parser.add_argument("--gh-pass", "-P", type=str,
+                        help="Github password of triager")
+    parser.add_argument("--gh-token", "-T", type=str,
+                        help="Github token of triager")
+    parser.add_argument("--verbose", "-v", action="store_true",
+                        help="Verbose output")
+    parser.add_argument("--force", "-f", action="store_true",
+                        help="Do not ask questions")
+    parser.add_argument("--debug", "-d", action="store_true",
+                        help="Debug output")
+    parser.add_argument("--pause", "-p", action="store_true",
+                        help="Always pause between PRs")
+    parser.add_argument("--pr", type=int,
+                        help="Triage only the specified pr")
+    parser.add_argument("--start-at", type=int,
+                        help="Start triage at the specified pr")
+    args = parser.parse_args()
+
+    if args.pr and args.start_at:
+        print("Error: Mutually exclusive: --start-at and --pr",
+              file=sys.stderr)
+        sys.exit(1)
+
+    if args.force and args.pause:
+        print("Error: Mutually exclusive: --force and --pause",
+              file=sys.stderr)
+        sys.exit(1)
+
+    triage = Triage(
+        verbose=args.verbose,
+        github_user=args.gh_user,
+        github_pass=args.gh_pass,
+        github_token=args.gh_token,
+        github_repo=args.repo,
+        pr_number=args.pr,
+        start_at_pr=args.start_at,
+        always_pause=args.pause,
+        force=args.force,
+    )
+    triage.run()
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
@gregdek please give it a shot. 

Did not test the API calls for creating, removing labels and adding comments but it _should_ work.

As the previous bot, it asks and prints the actions before doing any work. Use `-v` for more verbosity. I also implemented `-f` for non-interactive mode. This may be useful for webhooks (or travis) on a new PRs event.

~~~
$ pip install pygithub
$ ./triage.py 
usage: triage.py [-h] [--gh-user GH_USER] [--gh-pass GH_PASS]
                 [--gh-token GH_TOKEN] [--verbose] [--force] [--debug]
                 [--pause] [--pr PR] [--start-at START_AT]
                 {core,extras}
~~~
E.g.
~~~
 $ ./triage.py --gh-user gregdek --gh-pass <your_pass>  extras -v
~~~