### PR TITLE
fix maintainer user name not detected if has capital letters

### DIFF
--- a/triage.py
+++ b/triage.py
@@ -397,7 +397,7 @@ class Triage:
                            "( %s )" % comment.user.login)
                 break
 
-            if comment.user.login in module_maintainers:
+            if comment.user.login.lower() in module_maintainers:
                 self.debug(msg="%s is module maintainer commented on %s." %
                            (comment.user.login, comment.created_at))
 


### PR DESCRIPTION
we used lowercase in the maintainers files but the real username may contain capital letters