### PR TITLE
triage: implement new owner_pr process

### DIFF
--- a/templates/community_review_owner_pr.j2
+++ b/templates/community_review_owner_pr.j2
@@ -1,0 +1,4 @@
+Thanks again to @{{ submitter }}. This module is going into community review.
+We notice that you are one of the maintainers (@{{ maintainer|join(', @') }}) of this module, so when you think it's ready, please comment "shipit" and we will consider it for merging.
+
+[This message brought to you by your friendly Ansibull-bot.]

--- a/templates/shipit_owner_pr.j2
+++ b/templates/shipit_owner_pr.j2
@@ -1,3 +1,3 @@
-Thanks @{{ submitter }}. Since you are one of the maintainers (@{{ maintainer|join(', @') }}) of this module, we are marking this PR for inclusion.
+Thanks @{{ submitter }}. Since you are one of the maintainers (@{{ maintainer|join(', @') }}) of this module and you commented with "shipit", we are marking this PR for inclusion.
 
 [This message brought to you by your friendly Ansibull-bot.]

--- a/triage.py
+++ b/triage.py
@@ -38,7 +38,8 @@ ALIAS_LABELS = {
     ],
     'community_review': [
         'community_review_existing',
-        'community_review_new'
+        'community_review_new',
+        'community_review_owner_pr',
     ],
     'shipit': [
         'shipit_owner_pr'
@@ -345,9 +346,9 @@ class Triage:
             return
 
         if self.pull_request.get_pr_submitter() in module_maintainers:
-            self.debug(msg="plugin by owner, shipit as owner_pr")
+            self.debug(msg="plugin by owner, communtiy review as owner_pr")
             self.pull_request.add_desired_label(name="owner_pr")
-            self.pull_request.add_desired_label(name="shipit_owner_pr")
+            self.pull_request.add_desired_label(name="community_review_owner_pr")
             return
 
         if "shipit" in self.pull_request.get_current_labels():
@@ -441,7 +442,11 @@ class Triage:
                 if ("shipit" in comment.body or "+1" in comment.body
                     or "LGTM" in comment.body):
                     self.debug(msg="...said shipit!")
-                    self.pull_request.add_desired_label(name="shipit")
+                    # if maintainer was the submitter:
+                    if comment.user.login == self.pull_request.get_pr_submitter():
+                        self.pull_request.add_desired_label(name="shipit_owner_pr")
+                    else:
+                        self.pull_request.add_desired_label(name="shipit")
                     break
 
                 elif "needs_revision" in comment.body:


### PR DESCRIPTION
Closes #54

@gregdek: FYI, found 2 PR e1370 and e1931 where I quick removed owner_pr and then ran the bot, which gave the result wanted.

actually I noticed the owner_pr is not even needed... we can get rid of if you like, I would keep it.