### PR TITLE
put labels according ansible member comments

### DIFF
--- a/triage.py
+++ b/triage.py
@@ -297,6 +297,10 @@ class Triage:
             if current_label in MUTUALLY_EXCLUSIVE_LABELS:
                 self.pull_request.add_desired_label(name=current_label)
 
+    def is_ansible_member(self, login):
+        user = self._connect().get_user(login)
+        return self._connect().get_organization("ansible").has_in_members(user)
+
     def add_desired_labels_for_not_mergeable(self):
         """Adds labels for not mergeable conditions"""
         if not self.pull_request.is_mergeable():
@@ -498,6 +502,28 @@ class Triage:
                             name="community_review_existing"
                         )
                     break
+
+            if (comment.user.login not in BOTLIST
+                and self.is_ansible_member(comment.user.login)):
+
+                self.debug(msg="%s is a ansible member" % comment.user.login)
+
+                if ("shipit" in comment.body or "+1" in comment.body
+                    or "LGTM" in comment.body):
+                    self.debug(msg="...said shipit!")
+                    self.pull_request.add_desired_label(name="shipit")
+                    break
+
+                elif "needs_revision" in comment.body:
+                    self.debug(msg="...said needs_revision!")
+                    self.pull_request.add_desired_label(name="needs_revision")
+                    break
+
+                elif "needs_info" in comment.body:
+                    self.debug(msg="...said needs_info!")
+                    self.pull_request.add_desired_label(name="needs_info")
+                    break
+
         self.debug(msg="--- END Processing Comments")
 
     def render_comment(self, boilerplate=None):


### PR DESCRIPTION
suggested implementation for #73 

/cc @gregdek

~~~
PR #2007: Added pvs parameter to lvol module
Created at 2016-04-11 18:47:40
Updated at 2016-04-16 12:16:33
Debug: PR is mergeable
Debug: shipit labeled, skipping maintainer
Debug: --- START Processing Comments:
Debug: resmo is a ansible member
Debug: ...said needs_revision!
Debug: --- END Processing Comments
Debug: Build state is success
Debug: Thanks @p53 for this PR. This PR requires revisions, either because it fails to build or by reviewer request. Please make the suggested revisions. When you are done, please comment with text 'ready_for_review' and we will put this PR back into review.

[This message brought to you by your friendly Ansibull-bot.]
Submitter: p53
Maintainers: jhoekx, abulimov
Current Labels: shipit
Actions: {'newlabel': ['needs_revision'], 'comments': [u"Thanks @p53 for this PR. This PR requires revisions, either because it fails to build or by reviewer request. Please make the suggested revisions. When you are done, please comment with text 'ready_for_review' and we will put this PR back into review.\n\n[This message brought to you by your friendly Ansibull-bot.]"], 'unlabel': [u'shipit']}

~~~