### PR TITLE
Remove myself from the Docker module maintainers

### DIFF
--- a/MAINTAINERS-CORE.txt
+++ b/MAINTAINERS-CORE.txt
@@ -32,7 +32,7 @@ cloud/azure/azure.py: nitzmahone
 cloud/digital_ocean/digital_ocean.py: ansible
 cloud/digital_ocean/digital_ocean_domain.py: mgregson
 cloud/digital_ocean/digital_ocean_sshkey.py: mgregson
-cloud/docker/docker.py: cove softzilla smashwilson zfil ThomasSteinbach
+cloud/docker/docker.py: cove softzilla zfil ThomasSteinbach
 cloud/docker/docker_image.py: ansible
 cloud/google/gc_storage.py: bennojoy
 cloud/google/gce.py: erjohnso


### PR DESCRIPTION
I haven't been using the module myself for quite some time now, so it'd be best to let the opinions of others guide it forward. Also, I just haven't had the bandwidth to spare these days.