### PR TITLE
Remove double spaces which confuse Ansibull-bot

### DIFF
--- a/MAINTAINERS-CORE.txt
+++ b/MAINTAINERS-CORE.txt
@@ -30,8 +30,8 @@ cloud/amazon/route53.py: bpennypacker
 cloud/amazon/s3.py: ansible
 cloud/azure/azure.py: nitzmahone
 cloud/digital_ocean/digital_ocean.py: alukovenko
-cloud/digital_ocean/digital_ocean_domain.py: mgregson alukovenko  
-cloud/digital_ocean/digital_ocean_sshkey.py: mgregson alukovenko  
+cloud/digital_ocean/digital_ocean_domain.py: mgregson alukovenko
+cloud/digital_ocean/digital_ocean_sshkey.py: mgregson alukovenko
 cloud/docker/docker.py: cove softzilla zfil ThomasSteinbach
 cloud/docker/docker_image.py: ansible
 cloud/google/gc_storage.py: bennojoy
@@ -100,7 +100,7 @@ network/basics/slurp.py: ansible
 network/basics/uri.py: romeotheriault
 network/cumulus/: CumulusNetworks privateip gundalow
 network/eos/eos_command.py: privateip gundalow
-network/eos/eos_config.py: privateip  gundalow
+network/eos/eos_config.py: privateip gundalow
 network/eos/eos_eapi.py: chouseknecht privateip gundalow
 network/eos/eos_template.py: privateip gundalow
 network/ios/: privateip gundalow


### PR DESCRIPTION
With a double space you get:
(@privateip, @, @gundalow, @chouseknecht, @privateip, @gundalow)

I'll raise a bug https://github.com/ansible/ansibullbot/issues/116 to fix the parser

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ansible/ansibullbot/117)
<!-- Reviewable:end -->
