### PR TITLE
Remove chouseknecht as network maintainer

### DIFF
--- a/MAINTAINERS-CORE.txt
+++ b/MAINTAINERS-CORE.txt
@@ -106,7 +106,7 @@ network/basics/uri.py: romeotheriault
 network/cumulus/: CumulusNetworks privateip gundalow
 network/eos/eos_command.py: privateip gundalow
 network/eos/eos_config.py: privateip gundalow
-network/eos/eos_eapi.py: chouseknecht privateip gundalow
+network/eos/eos_eapi.py: privateip gundalow
 network/eos/eos_template.py: privateip gundalow
 network/ios/: privateip gundalow
 network/iosxr/: privateip gundalow


### PR DESCRIPTION
chouseknecht wrote some of the modules, however it's Peter and I that now maintain them.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ansible/ansibullbot/135)
<!-- Reviewable:end -->
