### PR TITLE
f5/bigip_gtm_wide_ip.py now owned by f5

### DIFF
--- a/MAINTAINERS-EXTRAS.txt
+++ b/MAINTAINERS-EXTRAS.txt
@@ -95,7 +95,6 @@ network/cloudflare_dns.py: mgruener
 network/dnsimple.py: drcapulet
 network/dnsmadeeasy.py: briceburg
 network/f5/: mhite caphrim007
-network/f5/bigip_gtm_wide_ip.py: perzizzle
 network/f5/bigip_monitor_http.py: srvg
 network/f5/bigip_monitor_tcp.py: srvg
 network/f5/bigip_virtual_server.py: Etienne-Carriere


### PR DESCRIPTION
network/f5/bigip_gtm_wide_ip.py is now maintained by the F5 group

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ansible/ansibullbot/136)
<!-- Reviewable:end -->
