### PR TITLE
triage: create issue in repo of ansibulbot if maintainer is unknown

### DIFF
--- a/templates/pending_maintainer_unknown.j2
+++ b/templates/pending_maintainer_unknown.j2
@@ -1,1 +1,5 @@
-maintainer unknown ping @gregdek @resmo @robynbergeron.
+Thanks @{{ submitter }}. I don't know who maintains this module, but I come back to it shortly.
+
+bot:maintainer_unknown
+
+[This message brought to you by your friendly Ansibull-bot.]

--- a/triage.py
+++ b/triage.py
@@ -430,6 +430,14 @@ class TriagePullRequests:
                 name="community_review_existing"
             )
 
+    def create_issue_for_ansibullbot(self):
+        title = "missing maintainer: #%s in %s" % (self.pull_request.pr_number, self.github_repo)
+        body = "See https://github.com/ansible/ansible-modules-%s/pull/%s" % (self.github_repo, self.pull_request.pr_number)
+        repo = self._connect().get_repo("ansible/ansibullbot")
+        issue = repo.create_issue(title=title, body=body)
+        self.debug(msg="Created an issue %s on ansible/ansibullbot" % issue.number)
+        return issue
+
     def process_comments(self):
         """ Processes PR comments for matching criteria for adding labels"""
         module_maintainers = self.get_module_maintainers()
@@ -736,6 +744,9 @@ class TriagePullRequests:
             self.pull_request.add_label(label=newlabel)
         for comment in self.actions['comments']:
             self.debug(msg="API Call comment: " + comment)
+            if 'bot:maintainer_unknown' in comment:
+                issue = self.create_issue_for_ansibullbot()
+                comment = comment + "\n created issue: https://github.com/ansible/ansibullbot/issue/%s" % issue.number
             self.pull_request.add_comment(comment=comment)
 
     def run(self):


### PR DESCRIPTION
/cc @jctanner @gundalow 
as discussed yesterday, any improvments?

```
 $ ./triage.py --gh-token ... core -v --pr 4831

PR #4831: sros_config: rename arugment from default to defaults
Created at 2016-09-14 11:38:32
Updated at 2016-09-14 17:18:24
Debug: unknown maintainer.
Debug: --- START Processing Comments:
Debug: gundalow is a ansible member
Debug: resmo is a ansible member
Debug: gregdek is in botlist: 
Debug: Days since last bot comment: 0
Debug: STATUS: no useful state change since last pass( gregdek )
Debug: --- END Processing Comments
Debug: PR is mergeable
Debug: Build state is success
Debug: Thanks @privateip. I don't know who maintains this module, but I come back to it shortly.

bot:maintainer_unknown

[This message brought to you by your friendly Ansibull-bot.]
Submitter: privateip
Maintainers: 
Current Labels: bugfix_pull_request, networking
Actions: {'newlabel': ['pending_action'], 'comments': [u"Thanks @privateip. I don't know who maintains this module, but I come back to it shortly.\n\nbot:maintainer_unknown\n\n[This message brought to you by your friendly Ansibull-bot.]"], 'unlabel': []}
Take recommended actions (y/N/a)? y
Debug: API Call newlabel: pending_action
Debug: API Call comment: Thanks @privateip. I don't know who maintains this module, but I come back to it shortly.

bot:maintainer_unknown

[This message brought to you by your friendly Ansibull-bot.]
Debug: Created an issue 150 on ansible/ansibullbot
```

See issue created #150 
