### PR TITLE
Move ownership of gce_img module

### DIFF
--- a/MAINTAINERS-EXTRAS.txt
+++ b/MAINTAINERS-EXTRAS.txt
@@ -37,7 +37,7 @@ cloud/amazon/sts_session_token.py: pwnall
 cloud/centurylink/: clc-runner
 cloud/cloudstack/: resmo dazworrall
 cloud/docker/docker_login.py: olsaki
-cloud/google/gce_img.py: tanpeter
+cloud/google/gce_img.py: supertom
 cloud/google/gce_tag.py: dohoangkhiemgmail.com
 cloud/lxc/lxc_container.py: cloudnull
 cloud/lxd/: hnakamur


### PR DESCRIPTION
tanpeter is ceding ownership of the gce_img module as Tom has been actively working on the other Google modules.