### PR TITLE
Set global maintainer for vmware back to chrrrles

### DIFF
--- a/MAINTAINERS-EXTRAS.txt
+++ b/MAINTAINERS-EXTRAS.txt
@@ -54,7 +54,7 @@ cloud/profitbricks/: baldwinSPC
 cloud/rackspace/: smashwilson
 cloud/softlayer/sl_vm.py: mcltn
 cloud/smartos/: xen0l
-cloud/vmware/: jctanner
+cloud/vmware/: chrrrles
 cloud/vmware/vca_: privateip
 cloud/vmware/vmware_: jcpowermac mtnbikenc
 cloud/vmware/vmware_guest: jctanner


### PR DESCRIPTION
undo change made by https://github.com/ansible/ansibullbot/commit/ae4cf905c3a5de59eca414d69e0a37f79a7dfdf5