### PR TITLE
Add n0trax as apache2_module maintainer

### DIFF
--- a/MAINTAINERS-CORE.txt
+++ b/MAINTAINERS-CORE.txt
@@ -154,7 +154,7 @@ utilities/logic/include_vars.py: bennojoy
 utilities/logic/pause.py: tbielawa
 utilities/logic/set_fact.py: dagwieers
 utilities/logic/wait_for.py: gregswift
-web_infrastructure/apache2_module.py: robinro
+web_infrastructure/apache2_module.py: robinro n0trax
 web_infrastructure/django_manage.py: tastychutney scottanderson42
 web_infrastructure/htpasswd.py: ansible
 web_infrastructure/supervisorctl.py: mattupstate inetfuture


### PR DESCRIPTION
As discussed in
https://github.com/ansible/ansible-modules-core/pull/5454#issuecomment-257960268
@n0trax should be added as maintainer of apache2_module

@n0trax is very active in answering issues, reviewing pull requests and did a major rewrite of the module already in https://github.com/ansible/ansible-modules-core/pull/2417