### PR TITLE
Fix Nonetype attribute error

### DIFF
--- a/lib/utils/extractors.py
+++ b/lib/utils/extractors.py
@@ -5,16 +5,19 @@ import re
 import shlex
 
 def extract_template_data(body, issue_number=None, issue_class='issue'):
-    SECTIONS = ['ISSUE TYPE', 'COMPONENT NAME', 'PLUGIN NAME', 
-                'ANSIBLE VERSION', 'CONFIGURATION', 
-                'OS / ENVIRONMENT', 'SUMMARY', 'ENVIRONMENT', 
+    SECTIONS = ['ISSUE TYPE', 'COMPONENT NAME', 'PLUGIN NAME',
+                'ANSIBLE VERSION', 'CONFIGURATION',
+                'OS / ENVIRONMENT', 'SUMMARY', 'ENVIRONMENT',
                 'STEPS TO REPRODUCE', 'EXPECTED RESULTS',
                 'ACTUAL RESULTS']
 
-    ISSUE_TYPES = ['Bug Report', 'Feature Idea', 
+    ISSUE_TYPES = ['Bug Report', 'Feature Idea',
                    'Feature Request', 'Documentation Report']
 
     tdict = {} #this is the final result to return
+
+    if not body:
+        return tdict
 
     upper_body = body.upper()
 
@@ -23,7 +26,7 @@ def extract_template_data(body, issue_number=None, issue_class='issue'):
     for section in SECTIONS:
         # http://www.tutorialspoint.com/python/string_find.htm
         # str.find(str, beg=0 end=len(string))        
-        match = upper_body.find(section)                 
+        match = upper_body.find(section)
         if match != -1:
             match_map[section] = match
     if not match_map:
@@ -40,7 +43,7 @@ def extract_template_data(body, issue_number=None, issue_class='issue'):
         # if last index, slice to the end
         if idx >= total_indexes:
             tdict[x[0]] = body[start_index:]
-        else:        
+        else:
             # slice to the next section
             stop_index = match_map[idx+1][1]
             tdict[x[0]] = body[start_index:stop_index]


### PR DESCRIPTION
```
Issue #18757 [0]: Fix link from dynamic inventory page to dev guide page
https://github.com/ansible/ansible/pull/18757
Created at 2016-12-05 21:15:28
Updated at 2016-12-05 21:15:28
Traceback (most recent call last):
  File "./triage.py", line 892, in <module>
    main()
  File "./triage.py", line 868, in main
    triage.run()
  File "/home/jtanner/workspace/github/jctanner/ansibullbot.prod/lib/triagers/pulltriager.py", line 83, in run
    self.process()
  File "/home/jtanner/workspace/github/jctanner/ansibullbot.prod/lib/triagers/ansible_ansible_pulltriager.py", line 127, in process
    self._process()
  File "/home/jtanner/workspace/github/jctanner/ansibullbot.prod/lib/triagers/defaulttriager.py", line 176, in _process
    self.template_data = self.issue.get_template_data()
  File "/home/jtanner/workspace/github/jctanner/ansibullbot.prod/lib/wrappers/defaultwrapper.py", line 315, in get_template_data
    extract_template_data(self.instance.body, issue_number=self.number, issue_class=issue_class)
  File "/home/jtanner/workspace/github/jctanner/ansibullbot.prod/lib/utils/extractors.py", line 19, in extract_template_data
    upper_body = body.upper()
AttributeError: 'NoneType' object has no attribute 'upper'
```