### PR TITLE
Updates maintainers to add F5 devs for all F5 modules

### DIFF
--- a/MAINTAINERS.txt
+++ b/MAINTAINERS.txt
@@ -259,9 +259,6 @@ network/dnsimple.py: drcapulet
 network/dnsmadeeasy.py: briceburg
 network/eos/: privateip gundalow Qalthos
 network/exoscale/: resmo
-network/f5/bigip_monitor_http.py: srvg
-network/f5/bigip_monitor_tcp.py: srvg
-network/f5/bigip_virtual_server.py: Etienne-Carriere
 network/f5/: mhite caphrim007 gundalow Qalthos privateip
 network/haproxy.py: ravibhure
 network/illumos/: xen0l


### PR DESCRIPTION
This patch updates the F5 modules so that F5 devs are the maintainers
for all of them and so that the community contributors are no longer
on the hook for their support