### PR TITLE
uri -> ansible

### DIFF
--- a/MAINTAINERS.txt
+++ b/MAINTAINERS.txt
@@ -251,7 +251,7 @@ network/asa/: gundalow Qalthos privateip
 network/avi/: grastogi23 khaltore ericsysmin
 network/basics/get_url.py: jpmens
 network/basics/slurp.py: ansible
-network/basics/uri.py: romeotheriault
+network/basics/uri.py: ansible
 network/citrix/netscaler.py: ansible
 network/cloudflare_dns.py: mgruener
 network/cumulus/: CumulusNetworks privateip gundalow Qalthos


### PR DESCRIPTION
romeotheriault doesn't exist on GitHub anymore (or there is a typo in the module *and* this file)

Eitherway this is a `'supported_by': 'core'` module, so proposing we take ownership of it

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ansible/ansibullbot/291)
<!-- Reviewable:end -->
