### PR TITLE
Make willthames fallthrough maintainer for cloud/amazon

### DIFF
--- a/MAINTAINERS.txt
+++ b/MAINTAINERS.txt
@@ -1,3 +1,4 @@
+cloud/amazon/: willthames
 cloud/amazon/cloudformation_facts.py: jmenga
 cloud/amazon/cloudformation.py: tedder ryansb
 cloud/amazon/cloudtrail.py: ansible


### PR DESCRIPTION
If a module under cloud/amazon has no maintainer, willthames
will be maintainer by default