### PR TITLE
Add ovirt label & classifier for ovirt PRs

### DIFF
--- a/lib/triagers/ansible.py
+++ b/lib/triagers/ansible.py
@@ -115,6 +115,7 @@ class AnsibleTriage(DefaultTriager):
         'cloud/amazon': "aws",
         'cloud/azure': "azure",
         'cloud/openstack': "openstack",
+        'cloud/ovirt': "ovirt",
         'cloud/digital_ocean': "digital_ocean",
         'windows': "windows",
         'network': "networking"
@@ -2365,6 +2366,7 @@ class AnsibleTriage(DefaultTriager):
             'cloud',
             'aws',
             'azure',
+            'ovirt',
             'digital_ocean',
             'docker',
             'gce',

--- a/lib/triagers/defaulttriager.py
+++ b/lib/triagers/defaulttriager.py
@@ -77,7 +77,7 @@ class DefaultTriager(object):
     BOTLIST = ['gregdek', 'robynbergeron', 'ansibot']
     VALID_ISSUE_TYPES = ['bug report', 'feature idea', 'documentation report']
     IGNORE_LABELS = [
-        "aws","azure","cloud",
+        "aws","azure","cloud", "ovirt",
         "feature_pull_request",
         "feature_idea",
         "bugfix_pull_request",


### PR DESCRIPTION
The oVirt team wants to use Ansible GH instead of their issue tracker for the modules, and have requested that we have an oVirt label so they're able to find & tag issues that apply to them.