### PR TITLE
Remove submitter from community list after shipit calculations

### DIFF
--- a/lib/triagers/ansible.py
+++ b/lib/triagers/ansible.py
@@ -1798,6 +1798,8 @@ class AnsibleTriage(DefaultTriager):
                         shipit_actors.append(actor)
                     continue
 
+        community = [x for x in community if x != iw.submitter]
+
         nmeta['shipit_count_community'] = community_shipits
         nmeta['shipit_count_maintainer'] = maintainer_shipits
         nmeta['shipit_count_ansible'] = ansible_shipits


### PR DESCRIPTION
to prevent pinging them with the "namespace maintainer" template.