### PR TITLE
network/cumulus/: notify individuals not the group

### DIFF
--- a/MAINTAINERS.txt
+++ b/MAINTAINERS.txt
@@ -258,7 +258,7 @@ network/basics/slurp.py: ansible
 network/basics/uri.py: ansible
 network/citrix/netscaler.py: ansible
 network/cloudflare_dns.py: mgruener
-network/cumulus/:  isharacomix jrrivers privateip gundalow Qalthos
+network/cumulus/: isharacomix jrrivers privateip gundalow Qalthos
 network/dellos10/: dhivyap skg-net privateip gundalow Qalthos
 network/dellos6/: dhivyap skg-net privateip gundalow Qalthos
 network/dellos9/: dhivyap skg-net privateip gundalow Qalthos

--- a/MAINTAINERS.txt
+++ b/MAINTAINERS.txt
@@ -258,7 +258,7 @@ network/basics/slurp.py: ansible
 network/basics/uri.py: ansible
 network/citrix/netscaler.py: ansible
 network/cloudflare_dns.py: mgruener
-network/cumulus/: CumulusNetworks privateip gundalow Qalthos
+network/cumulus/:  isharacomix jrrivers privateip gundalow Qalthos
 network/dellos10/: dhivyap skg-net privateip gundalow Qalthos
 network/dellos6/: dhivyap skg-net privateip gundalow Qalthos
 network/dellos9/: dhivyap skg-net privateip gundalow Qalthos


### PR DESCRIPTION
Previously we were notifying a group (GitHub org) which worked, though Ansibot doesn't know is in that group, so we didn't get owner_pr, etc set.

https://github.com/ansible/ansible/pull/21101#issuecomment-280040472

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ansible/ansibullbot/373)
<!-- Reviewable:end -->
