### PR TITLE
Allow submitter to use bot_status command

### DIFF
--- a/lib/triagers/ansible.py
+++ b/lib/triagers/ansible.py
@@ -2535,6 +2535,7 @@ class AnsibleTriage(DefaultTriager):
             if 'bot_status' in ev['body']:
                 if ev['actor'] not in self.BOTNAMES:
                     if ev['actor'] in self.ansible_core_team or \
+                            ev['actor'] == iw.submitter or \
                             ev['actor'] in self.module_indexer.all_maintainers:
                         bs = True
                         continue


### PR DESCRIPTION
[ISSUE_HELP.md](https://github.com/pilou-/ansibullbot/blob/allow_submitter_to_use_bot_status/ISSUE_HELP.md) states that submitters are allowed to use `bot_status`, so be it.