### PR TITLE
Removing maintainer

### DIFF
--- a/MAINTAINERS.txt
+++ b/MAINTAINERS.txt
@@ -273,7 +273,7 @@ network/dnsimple.py: drcapulet
 network/dnsmadeeasy.py: briceburg
 network/eos/: privateip
 network/exoscale/: resmo
-network/f5/: mhite caphrim007
+network/f5/: caphrim007
 network/haproxy.py: ravibhure
 network/illumos/: xen0l
 network/ios/: privateip rcarrillocruz


### PR DESCRIPTION
mhite has a long and storied past with the F5 modules, but in his
day-to-day work he deals with them much less and caphrim007, who
works at F5, has volunteered to take over the maintenance of all
the modules. Removing him so that he's not notified of future
issues/prs