### PR TITLE
network/nxos + mikewiebe

### DIFF
--- a/MAINTAINERS.txt
+++ b/MAINTAINERS.txt
@@ -293,7 +293,7 @@ network/netconf/netconf_config.py: lpenz userlerueda
 network/netvisor/: amitsi privateip gundalow Qalthos
 network/nmcli.py: alcamie101
 network/nsupdate.py: nerzhul
-network/nxos/: jedelman8 GGabriele rahushen privateip rcarrillocruz
+network/nxos/: jedelman8 GGabriele rahushen privateip rcarrillocruz mikewiebe
 network/ordnance/: djh00t alexanderturner
 network/omapi_host.py: nerzhul
 network/openswitch/: privateip gundalow Qalthos


### PR DESCRIPTION
Add Cisco's mikewiebe as a maintainer of the NXOS modules so he will be notified of issues and PRs. This will allow his `shipit` comments to be counted.