### PR TITLE
Allow to use log file located in current directory

### DIFF
--- a/lib/triagers/defaulttriager.py
+++ b/lib/triagers/defaulttriager.py
@@ -257,13 +257,10 @@ class DefaultTriager(object):
             logfile = '/tmp/ansibullbot.log'
 
         logdir = os.path.dirname(logfile)
-        if not os.path.isdir(logdir):
+        if logdir and not os.path.isdir(logdir):
             os.makedirs(logdir)
 
-        fileHandler = logging.FileHandler("{0}/{1}".format(
-                os.path.dirname(logfile),
-                os.path.basename(logfile))
-        )
+        fileHandler = logging.FileHandler(logfile)
         fileHandler.setFormatter(logFormatter)
         rootLogger.addHandler(fileHandler)
         consoleHandler = logging.StreamHandler()


### PR DESCRIPTION
Currently, the following command fails:
```
$ ./triage_ansible.py --dry-run --verbose --pr 24625 --logfile log.txt
Traceback (most recent call last):
  File "./triage_ansible.py", line 117, in <module>
    main()
  File "./triage_ansible.py", line 113, in main
    AnsibleTriage(args).start()
  File "/home/pilou/ansibullbot/lib/triagers/ansible.py", line 219, in __init__
    self.set_logger()
  File "/home/pilou/ansibullbot/lib/triagers/defaulttriager.py", line 261, in set_logger
    os.makedirs(logdir)
  File "/home/pilou/.v/ansibot2/lib/python2.7/os.py", line 157, in makedirs
    mkdir(name, mode)
OSError: [Errno 2] No such file or directory: ''
```