### PR TITLE
Don't fail when rate limit response doesn't contain requested information, improve consistency

### DIFF
--- a/lib/decorators/github.py
+++ b/lib/decorators/github.py
@@ -33,8 +33,14 @@ def get_rate_limit():
                 success = True
             except Exception:
                 time.sleep(60)
-    return rr.json()
 
+    response = rr.json()
+
+    if 'resources' not in response or 'core' not in response['resources']:
+        logging.warning('Unable to fetch rate limit %r', response['message'])
+        return False
+
+    return response
 
 def get_reset_time(fn, args):
     '''Return the number of seconds until the rate limit resets'''

--- a/lib/decorators/github.py
+++ b/lib/decorators/github.py
@@ -76,11 +76,12 @@ def RateLimited(fn):
             count += 1
             rl = get_rate_limit()
 
-            logging.debug('ratelimited call #%s [%s] [%s] [%s]' %
-                          (count,
-                           str(type(args[0])),
-                           fn.func_name,
-                           rl['resources']['core']['remaining']))
+            if rl:
+                logging.debug('ratelimited call #%s [%s] [%s] [%s]' %
+                              (count,
+                               type(args[0]),
+                               fn.func_name,
+                               rl['resources']['core']['remaining']))
 
             if count > 10:
                 logging.error('HIT 10 loop iteration on call, giving up')


### PR DESCRIPTION
* don't assume that rate limit response contain usable information
* [some code assumes](https://github.com/ansible/ansibullbot/blob/6fbf34c8c815b655b547bfa0e402cddec97df0b4/lib/decorators/github.py#L41) that `get_rate_limit` might return a `False` expression: improve consistency