### PR TITLE
Add giorgos-nikolopoulos and chiradeep as network/netscaler/ maintainers

### DIFF
--- a/MAINTAINERS.txt
+++ b/MAINTAINERS.txt
@@ -298,6 +298,7 @@ network/iosxr/: privateip rcarrillocruz
 network/junos/: Qalthos ganeshrn
 network/lenovo: dkasberg
 network/netconf/netconf_config.py: lpenz userlerueda ganeshrn
+network/netscaler/: giorgos-nikolopoulos chiradeep
 network/netvisor/: amitsi privateip gundalow Qalthos
 network/nxos/: jedelman8 GGabriele rahushen privateip rcarrillocruz mikewiebe trishnaguha
 network/openswitch/: privateip gundalow Qalthos


### PR DESCRIPTION
Since there is a Netscaler module in ansible 2.4 I am adding the maintainers for it and the upcoming modules.

Cheers