### PR TITLE
Use core if no supported_by

### DIFF
--- a/lib/triagers/ansible.py
+++ b/lib/triagers/ansible.py
@@ -1237,7 +1237,8 @@ class AnsibleTriage(DefaultTriager):
         # https://github.com/ansible/ansibullbot/issues/608
         cs_label = 'support:core'
         if self.meta['module_match']:
-            sb = self.meta['module_match']['metadata']['supported_by']
+            mm = self.meta['module_match']
+            sb = mm.get('metadata', {}).get('supported_by')
             if sb:
                 cs_label = 'support:%s' % sb
         if cs_label not in self.issue.labels:


### PR DESCRIPTION
```
2017-06-29 00:14:42,085 DEBUG https://api.github.com:443 "GET /rate_limit HTTP/1.1" 200 None
2017-06-29 00:14:42,104 DEBUG ratelimited call #1 [<class 'lib.wrappers.issuewrapper.IssueWrapper'>] [get_labels] [2861]
Traceback (most recent call last):
  File "./triage_ansible.py", line 117, in <module>
    main()
  File "./triage_ansible.py", line 113, in main
    AnsibleTriage(args).start()
  File "/home/ansibot/ansibullbot/lib/triagers/defaulttriager.py", line 278, in start
    self.loop()
  File "/home/ansibot/ansibullbot/lib/triagers/defaulttriager.py", line 763, in loop
    self.run()
  File "/home/ansibot/ansibullbot/lib/triagers/ansible.py", line 494, in run
    self.create_actions()
  File "/home/ansibot/ansibullbot/lib/triagers/ansible.py", line 1240, in create_actions
    sb = self.meta['module_match']['metadata']['supported_by']
KeyError: 'supported_by'
```