### PR TITLE
Add bondanthony as digital_ocean maintainer

### DIFF
--- a/MAINTAINERS.txt
+++ b/MAINTAINERS.txt
@@ -100,6 +100,7 @@ cloud/azure/azure_rm_deployment.py: devigned lmazuel
 cloud/centurylink/: clc-runner
 cloud/cloudscale/: gaudenz
 cloud/cloudstack/: resmo
+cloud/digital_ocean/: bondanthony
 cloud/digital_ocean/digital_ocean.py: alukovenko
 cloud/digital_ocean/digital_ocean_domain.py: mgregson alukovenko
 cloud/digital_ocean/digital_ocean_sshkey.py: mgregson alukovenko


### PR DESCRIPTION
The Digital Ocean cloud module has become stale and maintainers appear to have moved on to newer and bigger things. I would like to help reignite the Digital Ocean module development. Currently we have 5 different PRs that have been setting for a while. The DO API has introduced a number of new features that need modules or enhancements. Speeding up development on these DO modules will hopefully keep Ansible relevant in the DO community.