### PR TITLE
config: use boolean type, fix default string values

### DIFF
--- a/ansibullbot/constants.py
+++ b/ansibullbot/constants.py
@@ -211,7 +211,7 @@ DEFAULT_BREAKPOINTS = get_config(
     'breakpoints',
     '%s_BREAKPOINTS' % PROG_NAME.upper(),
     False,
-    value_type='string'
+    value_type='boolean'
 )
 
 DEFAULT_GITHUB_USERNAME = get_config(
@@ -219,7 +219,7 @@ DEFAULT_GITHUB_USERNAME = get_config(
     DEFAULTS,
     'github_username',
     '%s_GITHUB_USERNAME' % PROG_NAME.upper(),
-    False,
+    '',
     value_type='string'
 )
 
@@ -228,7 +228,7 @@ DEFAULT_GITHUB_PASSWORD = get_config(
     DEFAULTS,
     'github_password',
     '%s_GITHUB_PASSWORD' % PROG_NAME.upper(),
-    False,
+    '',
     value_type='string'
 )
 
@@ -237,7 +237,7 @@ DEFAULT_GITHUB_TOKEN = get_config(
     DEFAULTS,
     'github_token',
     '%s_GITHUB_TOKEN' % PROG_NAME.upper(),
-    False,
+    '',
     value_type='string'
 )
 
@@ -246,7 +246,7 @@ DEFAULT_SHIPPABLE_TOKEN = get_config(
     DEFAULTS,
     'shippable_token',
     '%s_SHIPPABLE_TOKEN' % PROG_NAME.upper(),
-    False,
+    '',
     value_type='string'
 )
 

--- a/ansibullbot/decorators/github.py
+++ b/ansibullbot/decorators/github.py
@@ -21,8 +21,7 @@ def get_rate_limit():
     password = C.DEFAULT_GITHUB_PASSWORD
     token = C.DEFAULT_GITHUB_TOKEN
 
-    if token != 'False':
-
+    if token:
         success = False
         while not success:
             try:

--- a/ansibullbot/triagers/defaulttriager.py
+++ b/ansibullbot/triagers/defaulttriager.py
@@ -433,7 +433,7 @@ class DefaultTriager(object):
     @RateLimited
     def _connect(self):
         """Connects to GitHub's API"""
-        if self.github_token != 'False' and self.github_token is not None:
+        if self.github_token:
             return Github(login_or_token=self.github_token)
         else:
             return Github(


### PR DESCRIPTION
This pull-request fix a HTTP 401 error (`Bad credentials`) which occurs when token is not set.

The cause of this error was this invalid HTTP header:
```{'Authorization': 'Bearer False', 'Accept': 'application/json'}```.