### PR TITLE
re-run CI on stalled pull-request with 'shipit'

### DIFF
--- a/ansibullbot/utils/shippable_api.py
+++ b/ansibullbot/utils/shippable_api.py
@@ -325,6 +325,22 @@ class ShippableRuns(object):
         return (run_data, commitSha, results, ci_verified)
 
 
+    def rebuild(self, run_number):
+        """trigger a new run"""
+        run_url = "%s&runNumbers=%s" % (ANSIBLE_RUNS_URL, run_number)
+        response = self.fetch(run_url)
+        if not response:
+            raise Exception("Unable to fetch %r" % run_url)
+        self.check_response(response)
+
+        run_id = response.json()[0]['id']
+
+        newbuild_url = "%s/projects/%s/newBuild" % (SHIPPABLE_URL, ANSIBLE_PROJECT_ID)
+        response = self.fetch(newbuild_url, verb='post', data=json.dumps({'runId':run_id}))
+        if not response:
+            raise Exception("Unable to fetch %r" % run_url)
+        self.check_response(response)
+
     def fetch(self, url, verb='get', **kwargs):
         resp = None
 


### PR DESCRIPTION
This pull-request allow to automatically re-run CI on pull-request labeled with both `shipit` and `stale_ci`.

This will facilitate contributors and maintainers workflows when a pull-request is labeled with `stale_ci`, avoiding submitter:

1. to rebase the branch pull-request in order to trigger the CI and to remove the `stale_ci` label;
2. to ask maintainer who had already approved a pull-request using the `shipit` command to use again the `shipit` command (because `shipit` counters are reset after a rebase).

I was not able to test (on a custom project) the HTTP request to `projects/{projectId}/newBuild`, this Shippable API [isn't usable](https://github.com/Shippable/support/issues/3628#issuecomment-305091311) using a free Shippable account.

Related: #459 #460