### PR TITLE
Allows automerge when deletion in sanity text files

### DIFF
--- a/ansibullbot/triagers/plugins/ci_rebuild.py
+++ b/ansibullbot/triagers/plugins/ci_rebuild.py
@@ -39,9 +39,6 @@ def get_rebuild_facts(iw, meta, shippable):
     if not meta['has_shippable']:
         return rbmeta
 
-    if meta['has_travis']:
-        return rbmeta
-
     if not meta['shipit']:
         return rbmeta
 

--- a/ansibullbot/triagers/plugins/shipit.py
+++ b/ansibullbot/triagers/plugins/shipit.py
@@ -28,9 +28,6 @@ def automergeable(meta, issuewrapper):
     if not issue.is_pullrequest():
         return False
 
-    if len(issue.files) > 1:
-        return False
-
     if meta['is_new_directory']:
         return False
 


### PR DESCRIPTION
This behavior was added by 369232a7d1285361b4e7d2d7902b763b9767e514, don't prevent it. See #659.