### PR TITLE
Adds the --resume argument to triage_ansible.py

### DIFF
--- a/ansibullbot/triagers/defaulttriager.py
+++ b/ansibullbot/triagers/defaulttriager.py
@@ -19,6 +19,7 @@ from __future__ import print_function
 
 import ConfigParser
 import glob
+import json
 import logging
 import os
 import sys
@@ -236,6 +237,50 @@ class DefaultTriager(object):
         # processed metadata
         self.meta = {}
     '''
+
+    @property
+    def resume(self):
+        '''Returns a dict with the last issue repo+number processed'''
+        if not hasattr(self, 'args'):
+            return None
+        if hasattr(self.args, 'pr') and self.args.pr:
+            return None
+        if not hasattr(self.args, 'resume'):
+            return None
+        if not self.args.resume:
+            return None
+
+        if hasattr(self, 'cachedir_base'):
+            resume_file = os.path.join(self.cachedir_base, 'resume.json')
+        else:
+            resume_file = os.path.join(self.cachedir, 'resume.json')
+        if not os.path.isfile(resume_file):
+            return None
+
+        with open(resume_file, 'rb') as f:
+            data = json.loads(f.read())
+        return data
+
+    def set_resume(self, repo, number):
+        if not hasattr(self, 'args'):
+            return None
+        if hasattr(self.args, 'pr') and self.args.pr:
+            return None
+        if not hasattr(self.args, 'resume'):
+            return None
+        if not self.args.resume:
+            return None
+
+        data = {
+            'repo': repo,
+            'number': number
+        }
+        if hasattr(self, 'cachedir_base'):
+            resume_file = os.path.join(self.cachedir_base, 'resume.json')
+        else:
+            resume_file = os.path.join(self.cachedir, 'resume.json')
+        with open(resume_file, 'wb') as f:
+            f.write(json.dumps(data, indent=2))
 
     def set_logger(self):
         if hasattr(self.args, 'debug') and self.args.debug:

--- a/triage_ansible.py
+++ b/triage_ansible.py
@@ -112,6 +112,8 @@ def main():
 
     parser.add_argument("--start-at", "--resume_id", type=int,
                         help="Start triage at the specified pr|issue")
+    parser.add_argument("--resume", action="store_true",
+                        help="pickup right after where the bot last stopped")
     parser.add_argument("--no_since", action="store_true",
                         help="Do not use the since keyword to fetch issues")
 


### PR DESCRIPTION
If used, each issue number will be recorded to a json file in the cachedir
when processing begins. If the bot is stopped or dies, on the next run,
it will read the json file, decrement the number and set args.start_at
This effectively resumes processing and skips the issue that is broken,
and gives a smoother experience when combined with a systemd autorestart.