### PR TITLE
Search authors using other formats

### DIFF
--- a/ansibullbot/utils/moduletools.py
+++ b/ansibullbot/utils/moduletools.py
@@ -588,9 +588,8 @@ class ModuleIndexer(object):
     def get_module_authors(self, module_file):
         """Grep the authors out of the module docstrings"""
 
-        authors = []
         if not os.path.exists(module_file):
-            return authors
+            return []
 
         documentation = ''
         inphase = False
@@ -607,7 +606,7 @@ class ModuleIndexer(object):
                     documentation += line
 
         if not documentation:
-            return authors
+            return []
 
         # clean out any other yaml besides author to save time
         inphase = False
@@ -627,18 +626,18 @@ class ModuleIndexer(object):
                 author_lines += x + '\n'
 
         if not author_lines:
-            return authors
+            return []
 
         ydata = {}
         try:
             ydata = yaml.load(author_lines)
         except Exception as e:
             print e
-            return authors
+            return []
 
         # quit early if the yaml was not valid
         if not ydata:
-            return authors
+            return []
 
         # sometimes the field is 'author', sometimes it is 'authors'
         if 'authors' in ydata:
@@ -646,11 +645,12 @@ class ModuleIndexer(object):
 
         # quit if the key was not found
         if 'author' not in ydata:
-            return authors
+            return []
 
         if type(ydata['author']) != list:
             ydata['author'] = [ydata['author']]
 
+        authors = []
         for author in ydata['author']:
             if 'ansible core team' in author.lower():
                 authors.append('ansible')

--- a/ansibullbot/utils/moduletools.py
+++ b/ansibullbot/utils/moduletools.py
@@ -652,35 +652,39 @@ class ModuleIndexer(object):
 
         authors = []
         for author in ydata['author']:
-            if 'ansible core team' in author.lower():
-                authors.append('ansible')
-            elif '@' in author:
-                words = author.split()
-                for word in words:
-                    if '@' in word and '(' in word and ')' in word:
-                        if '(' in word:
-                            word = word.split('(')[-1]
-                        if ')' in word:
-                            word = word.split(')')[0]
-                        word = word.strip()
-                        if word.startswith('@'):
-                            word = word.replace('@', '', 1)
-                            authors.append(word)
-            elif 'github.com/' in author:
-                # {'author': 'Henrique Rodrigues (github.com/Sodki)'}
-                idx = author.find('github.com/')
-                author = author[idx+11:]
-                author = author.replace(')', '')
-                authors.append(author)
-            elif '(' in author and len(author.split()) == 3:
-                # Mathieu Bultel (matbu)
-                idx = author.find('(')
-                author = author[idx+1:]
-                author = author.replace(')', '')
-            else:
-                pass
-
+            github_ids = self.extract_github_id(author)
+            if github_ids:
+                authors.extend(github_ids)
         return authors
+
+    def extract_github_id(self, author):
+        authors = set()
+        if 'ansible core team' in author.lower():
+            authors.add('ansible')
+        elif '@' in author:
+            words = author.split()
+            for word in words:
+                if '@' in word and '(' in word and ')' in word:
+                    if '(' in word:
+                        word = word.split('(')[-1]
+                    if ')' in word:
+                        word = word.split(')')[0]
+                    word = word.strip()
+                    if word.startswith('@'):
+                        word = word.replace('@', '', 1)
+                        authors.add(word)
+        elif 'github.com/' in author:
+            # {'author': 'Henrique Rodrigues (github.com/Sodki)'}
+            idx = author.find('github.com/')
+            author = author[idx+11:]
+            authors.add(author.replace(')', ''))
+        elif '(' in author and len(author.split()) == 3:
+            # Mathieu Bultel (matbu)
+            idx = author.find('(')
+            author = author[idx+1:]
+            authors.add(author.replace(')', ''))
+
+        return list(authors)
 
     def fuzzy_match(self, repo=None, title=None, component=None):
         '''Fuzzy matching for modules'''

--- a/ansibullbot/utils/moduletools.py
+++ b/ansibullbot/utils/moduletools.py
@@ -6,6 +6,7 @@ import datetime
 import logging
 import os
 import pickle
+import re
 import shutil
 import yaml
 
@@ -659,20 +660,13 @@ class ModuleIndexer(object):
 
     def extract_github_id(self, author):
         authors = set()
+
         if 'ansible core team' in author.lower():
             authors.add('ansible')
         elif '@' in author:
+            # match github ids but not emails
+            authors.update(re.findall(r'(?<!\w)@([\w-]+)(?![\w.])', author))
             words = author.split()
-            for word in words:
-                if '@' in word and '(' in word and ')' in word:
-                    if '(' in word:
-                        word = word.split('(')[-1]
-                    if ')' in word:
-                        word = word.split(')')[0]
-                    word = word.strip()
-                    if word.startswith('@'):
-                        word = word.replace('@', '', 1)
-                        authors.add(word)
         elif 'github.com/' in author:
             # {'author': 'Henrique Rodrigues (github.com/Sodki)'}
             idx = author.find('github.com/')

--- a/tests/unit/utils/test_githubid_extractor.py
+++ b/tests/unit/utils/test_githubid_extractor.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python
+
+import unittest
+from ansibullbot.utils.moduletools import ModuleIndexer
+
+class TestGitHubIdExtractor(unittest.TestCase):
+
+    def setUp(self):
+        obj = object()
+        self.extract = ModuleIndexer.extract_github_id.__get__(obj, ModuleIndexer)
+
+    def test_extract(self):
+        authors = [
+            ('First-Name Last (@k0-mIg)', ['k0-mIg']),  # expected format
+            ('Ansible Core Team', ['ansible']),  # special case
+            ('Ansible core Team', ['ansible']),  # special case
+            ('First Last (@firstlast) 2016, Another Last (@another) 2014', ['firstlast', 'another']),  # multiple ids
+            ('First Last @ Corp Team (@first-corp, @corp-team, @user)',['first-corp', 'corp-team', 'user']),  # multiple ids
+            ('First Last @github', ['github']),  # without parentheses
+            ('First Last (github)', ['github']),  # without at sign
+            ('First Last (github.com/Github)', ['Github']),  # prefixed
+        ]
+
+        for line, githubids in authors:
+            self.assertEqual(set(githubids), set(self.extract(line)))
+
+    def test_notfound(self):
+        authors = [
+            'firstname lastname',
+            'First Last (name@domain.example)',
+        ]
+
+        for line in authors:
+            self.assertFalse(self.extract(line))


### PR DESCRIPTION
Relates to #704.

Add support for:
- multiple GitHub IDs in one line: `team (@user1, @user2)` (used in [identity/cyberark/cyberark_user.py](https://github.com/ansible/ansible/blob/devel/lib/ansible/modules/identity/cyberark/cyberark_user.py#L16))
- GitHub IDs not surrounded by parentheses: `Name @id` (used in https://github.com/ansible/ansible/blob/devel/lib/ansible/modules/system/java_cert.py#L57)
