### PR TITLE
Find GitHub ID searching for email

### DIFF
--- a/ansibullbot/triagers/ansible.py
+++ b/ansibullbot/triagers/ansible.py
@@ -278,7 +278,7 @@ class AnsibleTriage(DefaultTriager):
         self.file_indexer = FileIndexer()
 
         logging.info('creating module indexer')
-        self.module_indexer = ModuleIndexer()
+        self.module_indexer = ModuleIndexer(gh_client=self.gqlc)
 
         # instantiate shippable api
         logging.info('creating shippable wrapper')

--- a/ansibullbot/utils/gh_gql_client.py
+++ b/ansibullbot/utils/gh_gql_client.py
@@ -286,6 +286,7 @@ class GithubGraphQLClient(object):
 
         template = self.environment.from_string(QUERY_TEMPLATE_BLAME)
         committers = defaultdict(set)
+        emailmap = {}
 
         query = template.render(OWNER=owner, REPO=repo, BRANCH=branch, PATH=filepath)
 
@@ -321,10 +322,12 @@ class GithubGraphQLClient(object):
             # - GraphQL/git 'blame' don't list all commits
             # - GraphQL 'history' neither because 'history' is like 'git log' but without '--follow'
             email = node['author'].get('email')
+            if email and email not in emailmap:
+                emailmap[email] = github_id
 
         for github_id, commits in committers.items():
             committers[github_id] = list(commits)
-        return committers
+        return committers, emailmap
 
     @retry(wait=wait_random(min=1, max=2), stop=stop_after_attempt(5))
     def requests(self, payload):

--- a/ansibullbot/utils/gh_gql_client.py
+++ b/ansibullbot/utils/gh_gql_client.py
@@ -7,7 +7,10 @@ import jinja2
 import json
 import logging
 import requests
+from collections import defaultdict
 from operator import itemgetter
+
+from tenacity import retry, wait_random, stop_after_attempt
 
 
 QUERY_FIELDS = """
@@ -51,6 +54,35 @@ QUERY_TEMPLATE_SINGLE_NODE = """
     }
 }
 """
+
+QUERY_TEMPLATE_BLAME = """
+query {
+  repository(owner: "{{ OWNER }}", name: "{{ REPO }}") {
+    ... on Repository {
+      ref(qualifiedName: "{{ BRANCH }}") {
+        target {
+          ... on Commit {
+            blame(path: "{{ PATH }}") {
+              ranges {
+                commit {
+                  oid
+                  author {
+                    email
+                    user {
+                      login
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+"""
+
 
 class GithubGraphQLClient(object):
     baseurl = 'https://api.github.com/graphql'
@@ -250,6 +282,55 @@ class GithubGraphQLClient(object):
 
         node['type'] = node_type
 
+    def get_usernames_from_filename_blame(self, owner, repo, branch, filepath):
+
+        template = self.environment.from_string(QUERY_TEMPLATE_BLAME)
+        committers = defaultdict(set)
+
+        query = template.render(OWNER=owner, REPO=repo, BRANCH=branch, PATH=filepath)
+
+        payload = {
+            'query': query.encode('ascii', 'ignore').strip(),
+            'variables': '{}',
+            'operationName': None
+        }
+        response = self.requests(payload)
+        data = response.json()
+
+        nodes = data['data']['repository']['ref']['target']['blame']['ranges']
+        """
+        [
+            'commit':
+            {
+                'oid': 'a3132e5dd6acc526ce575f6db134169c7090f72d',
+                'author':
+                {
+                    'email': 'user@mail.example',
+                    'user': {'login': 'user'}
+                }
+            }
+        ]
+        """
+        for node in nodes:
+            node = node['commit']
+            if not node['author']['user']:
+                continue
+            github_id = node['author']['user']['login']
+            committers[github_id].add(node['oid'])
+            # emails come from 'git log --follow' but all github id aren't fetch:
+            # - GraphQL/git 'blame' don't list all commits
+            # - GraphQL 'history' neither because 'history' is like 'git log' but without '--follow'
+            email = node['author'].get('email')
+
+        for github_id, commits in committers.items():
+            committers[github_id] = list(commits)
+        return committers
+
+    @retry(wait=wait_random(min=1, max=2), stop=stop_after_attempt(5))
+    def requests(self, payload):
+        response = requests.post(self.baseurl, headers=self.headers, data=json.dumps(payload))
+        response.raise_for_status()
+        return response
 
 ###################################
 # TESTING ...

--- a/ansibullbot/utils/moduletools.py
+++ b/ansibullbot/utils/moduletools.py
@@ -693,7 +693,7 @@ class ModuleIndexer(object):
             authors.add(author.replace(')', ''))
 
         # search for emails
-        for email in re.findall(r'[<(]([^@]+@[^>]+)[)>]', author):
+        for email in re.findall(r'[<(]([^@]+@[^)>]+)[)>]', author):
             github_id = self.emailmap.get(email)
             if github_id:
                 authors.add(github_id)

--- a/ansibullbot/utils/moduletools.py
+++ b/ansibullbot/utils/moduletools.py
@@ -682,6 +682,12 @@ class ModuleIndexer(object):
             author = author[idx+1:]
             authors.add(author.replace(')', ''))
 
+        # search for emails
+        for email in re.findall(r'[<(]([^@]+@[^>]+)[)>]', author):
+            github_id = self.emailmap.get(email)
+            if github_id:
+                authors.add(github_id)
+
         return list(authors)
 
     def fuzzy_match(self, repo=None, title=None, component=None):

--- a/ansibullbot/utils/moduletools.py
+++ b/ansibullbot/utils/moduletools.py
@@ -39,7 +39,7 @@ class ModuleIndexer(object):
         'imports': []
     }
 
-    def __init__(self, maintainers=None):
+    def __init__(self, maintainers=None, gh_client=None):
 
         self.botmeta = {}
         self.modules = {}
@@ -50,6 +50,7 @@ class ModuleIndexer(object):
         self.scraper_cache = '~/.ansibullbot/cache/ansible.modules.scraper'
         self.scraper_cache = os.path.expanduser(self.scraper_cache)
         self.gws = GithubWebScraper(cachedir=self.scraper_cache)
+        self.gqlc = gh_client
 
         # committers by module
         self.committers = {}
@@ -448,7 +449,10 @@ class ModuleIndexer(object):
                     refresh = True
 
             if refresh:
-                uns = self.gws.get_usernames_from_filename_blame(*sargs)
+                if self.gqlc:
+                    uns = self.gqlc.get_usernames_from_filename_blame(*sargs)
+                else:
+                    uns = self.gws.get_usernames_from_filename_blame(*sargs)
                 self.committers[k] = uns
                 with open(pfile, 'wb') as f:
                     pickle.dump((ghash, uns), f)

--- a/ansibullbot/utils/moduletools.py
+++ b/ansibullbot/utils/moduletools.py
@@ -666,7 +666,6 @@ class ModuleIndexer(object):
         elif '@' in author:
             # match github ids but not emails
             authors.update(re.findall(r'(?<!\w)@([\w-]+)(?![\w.])', author))
-            words = author.split()
         elif 'github.com/' in author:
             # {'author': 'Henrique Rodrigues (github.com/Sodki)'}
             idx = author.find('github.com/')

--- a/ansibullbot/utils/moduletools.py
+++ b/ansibullbot/utils/moduletools.py
@@ -275,19 +275,6 @@ class ModuleIndexer(object):
             mkey = mdict['filepath']
             self.modules[mkey] = mdict
 
-        # grep the authors:
-        for k,v in self.modules.iteritems():
-            if v['filepath'] is None:
-                continue
-            mfile = os.path.join(self.checkoutdir, v['filepath'])
-            authors = self.get_module_authors(mfile)
-            self.modules[k]['authors'] = authors
-
-            # authors are maintainers by -default-
-            self.modules[k]['maintainers'] += authors
-            self.modules[k]['maintainers'] = \
-                sorted(set(self.modules[k]['maintainers']))
-
         # meta is a special module
         self.modules['meta'] = copy.deepcopy(self.EMPTY_MODULE)
         self.modules['meta']['name'] = 'meta'
@@ -504,6 +491,20 @@ class ModuleIndexer(object):
 
     def set_maintainers(self):
         '''Define the maintainers for each module'''
+
+        # grep the authors:
+        for k,v in self.modules.iteritems():
+            if v['filepath'] is None:
+                continue
+            mfile = os.path.join(self.checkoutdir, v['filepath'])
+            authors = self.get_module_authors(mfile)
+            self.modules[k]['authors'] = authors
+
+            # authors are maintainers by -default-
+            self.modules[k]['maintainers'] += authors
+            self.modules[k]['maintainers'] = \
+                sorted(set(self.modules[k]['maintainers']))
+
         mkeys = self.maintainers.keys()
         for k,v in self.modules.iteritems():
             if not v['filepath']:

--- a/ansibullbot/utils/moduletools.py
+++ b/ansibullbot/utils/moduletools.py
@@ -445,17 +445,27 @@ class ModuleIndexer(object):
                     pdata = pickle.load(f)
                 if pdata[0] == ghash:
                     self.committers[k] = pdata[1]
+                    if len(pdata) == 3:
+                        # use emailmap if available
+                        emailmap = pdata[2]
+                    else:
+                        emailmap = {}
                 else:
                     refresh = True
 
             if refresh:
                 if self.gqlc:
-                    uns = self.gqlc.get_usernames_from_filename_blame(*sargs)
+                    uns, emailmap = self.gqlc.get_usernames_from_filename_blame(*sargs)
                 else:
+                    emailmap = {}  # scrapping: emails not available
                     uns = self.gws.get_usernames_from_filename_blame(*sargs)
                 self.committers[k] = uns
                 with open(pfile, 'wb') as f:
-                    pickle.dump((ghash, uns), f)
+                    pickle.dump((ghash, uns, emailmap), f)
+
+            for email, github_id in emailmap.items():
+                if email not in self.emailmap:
+                    self.emailmap[email] = github_id
 
         # add scraped logins to the map
         #for k,v in self.modules.iteritems():

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,4 +10,5 @@ requests
 requests_cache
 ruamel.yaml
 six
+tenacity
 textblob

--- a/tests/unit/utils/test_githubid_extractor.py
+++ b/tests/unit/utils/test_githubid_extractor.py
@@ -12,8 +12,8 @@ class ModuleIndexerMock(object):
 class TestGitHubIdExtractor(unittest.TestCase):
 
     def setUp(self):
-        obj = ModuleIndexerMock()
-        self.extract = ModuleIndexer.extract_github_id.__get__(obj, ModuleIndexer)
+        self.indexer = ModuleIndexerMock()
+        self.extract = ModuleIndexer.extract_github_id.__get__(self.indexer, ModuleIndexer)
 
     def test_extract(self):
         authors = [
@@ -38,3 +38,18 @@ class TestGitHubIdExtractor(unittest.TestCase):
 
         for line in authors:
             self.assertFalse(self.extract(line))
+
+    def test_extract_email(self):
+        self.indexer.emailmap = {
+            'first@last.example': 'github',
+            'last@domain.example': 'github2',
+        }
+
+        authors = [
+            ('First-Name Last (first@last.example)', ['github']),  # known email
+            ('First-Name Last <first@last.example>', ['github']),  # known email
+            ('First-Name Last (first@last.example), Surname Name (last@domain.example)', ['github', 'github2']),  # known emails
+        ]
+
+        for line, githubids in authors:
+            self.assertEqual(set(githubids), set(self.extract(line)))

--- a/tests/unit/utils/test_githubid_extractor.py
+++ b/tests/unit/utils/test_githubid_extractor.py
@@ -3,10 +3,16 @@
 import unittest
 from ansibullbot.utils.moduletools import ModuleIndexer
 
+
+class ModuleIndexerMock(object):
+    def __init__(self, *args, **kwargs):
+        self.emailmap = {}
+
+
 class TestGitHubIdExtractor(unittest.TestCase):
 
     def setUp(self):
-        obj = object()
+        obj = ModuleIndexerMock()
         self.extract = ModuleIndexer.extract_github_id.__get__(obj, ModuleIndexer)
 
     def test_extract(self):


### PR DESCRIPTION
The purpose of this pull request is to avoid to add module author in `.github/BOTMETA.yml` when `DOCUMENTATION.author` contains an email address but not an GitHub ID. `.github/BOTMETA.yml` should only be used when authors and maintainers differ (and `DOCUMENTATION.author` should contain GitHub ID).

Not that because `.github/BOTMETA.yml` already contains an entry for each module where `DOCUMENTATION.author` contains an email address but not an GitHub ID, nothing will change. But some entries in `.github/BOTMETA.yml` could be removed (the ones for which module authors and module maintainers are the same and `DOCUMENTATION.author` contains email address).

Commits explanation:
- second commit: implement `get_usernames_from_filename_blame` using GraphQL (allowing to map email address and GitHub ID)
- third commit: move authors initialization later, allowing `get_module_authors` to access `emailmap`
- fourth commit: use `get_usernames_from_filename_blame` using GraphQL (when Github token is set)
- fifth commit: `get_module_authors` search for email in `author` and use `emailmap`
- six commit: populate `emailmap` in GraphQL implementation of `get_usernames_from_filename_blame`

Relates: #704 