### PR TITLE
Handle PENGING reviews

### DIFF
--- a/ansibullbot/triagers/plugins/needs_revision.py
+++ b/ansibullbot/triagers/plugins/needs_revision.py
@@ -446,6 +446,9 @@ def get_review_state(reviews, submitter, number=None, www_validate=None,
                 # a dismissed review 'magically' turns into a comment
                 user_reviews[actor] = 'COMMENTED'
 
+            elif state == 'PENDING':
+                pass
+
             else:
                 logging.error('breakpoint!')
                 print('%s not handled yet' % state)

--- a/ansibullbot/wrappers/historywrapper.py
+++ b/ansibullbot/wrappers/historywrapper.py
@@ -644,13 +644,6 @@ class HistoryWrapper(object):
     def merge_reviews(self, reviews):
         for review in reviews:
             event = {}
-            event['id'] = review['id']
-            event['actor'] = review['user']['login']
-            event['created_at'] = self.parse_timestamp(review['submitted_at'])
-            event['commit_id'] = review['commit_id']
-
-            # keep these for shipit analysis
-            event['body'] = review.get('body')
 
             if review['state'] == 'COMMENTED':
                 event['event'] = 'review_comment'
@@ -660,12 +653,24 @@ class HistoryWrapper(object):
                 event['event'] = 'review_approved'
             elif review['state'] == 'DISMISSED':
                 event['event'] = 'review_dismissed'
+            elif review['state'] == 'PENDING':
+                # ignore pending review
+                continue
             else:
                 if C.DEFAULT_BREAKPOINTS:
                     logging.error('breakpoint!')
                     import epdb; epdb.st()
                 else:
                     raise Exception('unknown review state')
+
+            event['id'] = review['id']
+            event['actor'] = review['user']['login']
+            event['created_at'] = self.parse_timestamp(review['submitted_at'])
+            event['commit_id'] = review['commit_id']
+
+            # keep these for shipit analysis
+            event['body'] = review.get('body')
+
             self.history.append(event)
 
         self.fix_history_tz()


### PR DESCRIPTION
ansibot do not review pull requests but it fixes a potential exception when the bot is run locally:
```
File "ansibullbot/wrappers/historywrapper.py", line 649, in merge_reviews
    event['created_at'] = self.parse_timestamp(review['submitted_at'])
KeyError: 'submitted_at'
```