### PR TITLE
Handle closed pull requests (`mergeable_state` of merged pull requests is `unknown`)

### DIFF
--- a/ansibullbot/triagers/ansible.py
+++ b/ansibullbot/triagers/ansible.py
@@ -772,7 +772,7 @@ class AnsibleTriage(DefaultTriager):
 
         # UNKNOWN!!! ... sigh.
         if self.issue.is_pullrequest():
-            if self.meta['mergeable_state'] == 'unknown':
+            if self.meta['mergeable_state'] == 'unknown' and self.issue.state != 'closed':
                 msg = 'skipping %s because it has a' % self.issue.number
                 msg += ' mergeable_state of unknown'
                 logging.warning(msg)

--- a/ansibullbot/wrappers/defaultwrapper.py
+++ b/ansibullbot/wrappers/defaultwrapper.py
@@ -933,7 +933,7 @@ class DefaultWrapper(object):
 
     @property
     def mergeable_state(self):
-        if not self.is_pullrequest():
+        if not self.is_pullrequest() or self.pullrequest.state == 'closed':
             return None
 
         # http://stackoverflow.com/a/30620973


### PR DESCRIPTION
This pull request allows to use `--ignore_state` switch.

Note that `--ignore_state` switch is useful while debugging, however plugins might return inconsistent values when a closed pull request is processed: `--ignore_state` should not be used without `--dry-run`.