### PR TITLE
fix duplicate actions by unique'ing the list of numbers

### DIFF
--- a/ansibullbot/triagers/ansible.py
+++ b/ansibullbot/triagers/ansible.py
@@ -1674,7 +1674,7 @@ class AnsibleTriage(DefaultTriager):
             logging.info('%s numbers after checking type' % len(numbers))
 
         # Use iterator to avoid requesting all issues upfront
-        numbers = sorted([int(x) for x in numbers])
+        numbers = sorted(set([int(x) for x in numbers]))
         if self.args.sort == 'desc':
             numbers = [x for x in reversed(numbers)]
 


### PR DESCRIPTION
Many issues are getting duplicate notification and label events in a very small time window.

https://github.com/ansible/ansible/pull/29033

https://github.com/ansible/ansibullbot/commit/896405fa0c1a90da13a9510e3426f4552c723c91 removed unique'ing on the numbers from the repoiterator which has probably caused some issues to run twice in the same loop and possibly hit race conditions on labeling.

