### PR TITLE
SimpleIndexer: use file_indexer with IssueWrapper

### DIFF
--- a/ansibullbot/triagers/defaulttriager.py
+++ b/ansibullbot/triagers/defaulttriager.py
@@ -545,19 +545,6 @@ class DefaultTriager(object):
             merged = pr.merged
         return merged
 
-    def wrap_issue(self, github, repo, issue, header=None):
-        iw = IssueWrapper(
-            github=github,
-            repo=repo,
-            issue=issue,
-            cachedir=self.cachedir
-        )
-        if header:
-            iw.TEMPLATE_HEADER=header
-        if self.file_indexer:
-            iw.file_indexer = self.file_indexer
-        return iw
-
     def dump_action_dict(self, issue, actions):
         '''Serialize the action dict to disk for quick(er) debugging'''
         fn = os.path.join('/tmp', 'actions', issue.repo_full_name, str(issue.number) + '.json')

--- a/ansibullbot/triagers/simpletriager.py
+++ b/ansibullbot/triagers/simpletriager.py
@@ -32,7 +32,7 @@ import os
 from pprint import pprint
 from ansibullbot.triagers.defaulttriager import DefaultTriager, DefaultActions
 from ansibullbot.utils.file_tools import FileIndexer
-#from ansibullbot.wrappers.issuewrapper import IssueWrapper
+from ansibullbot.wrappers.issuewrapper import IssueWrapper
 from github.GithubException import UnknownObjectException
 
 
@@ -69,7 +69,7 @@ class SimpleTriager(DefaultTriager):
             actions = DefaultActions()
 
             # wrap the issue for extra magic
-            iw = self.wrap_issue(self.ghw, repo, issue)
+            iw = IssueWrapper(github=self.ghw, repo=repo, issue=issue, cachedir=self.cachedir, file_indexer=self.file_indexer)
 
             # what did the submitter provide in the body?
             td = iw.template_data


### PR DESCRIPTION
- `SimpleTriager`: use `file_indexer` parameter with `IssueWrapper`
- remove unused `DefaultTriager.wrap_issue`


