### PR TITLE
Improve usage of argparse.Namespace

### DIFF
--- a/ansibullbot/triagers/ansible.py
+++ b/ansibullbot/triagers/ansible.py
@@ -235,9 +235,7 @@ class AnsibleTriage(DefaultTriager):
         logging.info('starting bot')
 
         logging.debug('setting bot attributes')
-        attribs = dir(self.args)
-        attribs = [x for x in attribs if not x.startswith('_')]
-        for x in attribs:
+        for x in vars(self.args):
             try:
                 val = getattr(self.args, x)
                 if x.startswith('gh_'):

--- a/ansibullbot/triagers/defaulttriager.py
+++ b/ansibullbot/triagers/defaulttriager.py
@@ -158,9 +158,7 @@ class DefaultTriager(object):
         logging.info('starting bot')
 
         logging.debug('setting bot attributes')
-        attribs = dir(self.args)
-        attribs = [x for x in attribs if not x.startswith('_')]
-        for x in attribs:
+        for x in vars(self.args):
             val = getattr(self.args, x)
             if x.startswith('gh_'):
                 setattr(self, x.replace('gh_', 'github_'), val)


### PR DESCRIPTION
Use `vars` instead of `dir`.