### PR TITLE
Fix traceback in daemonize mode

### DIFF
--- a/ansibullbot/triagers/ansible.py
+++ b/ansibullbot/triagers/ansible.py
@@ -1559,7 +1559,8 @@ class AnsibleTriage(DefaultTriager):
                     if x[1]['created_at']
                 ]
                 ts = sorted(set(ts))
-                self.repos[repo]['since'] = ts[-1]
+                if ts:
+                    self.repos[repo]['since'] = ts[-1]
             else:
                 since = datetime.datetime.strptime(
                     self.repos[repo]['since'],

--- a/ansibullbot/utils/moduletools.py
+++ b/ansibullbot/utils/moduletools.py
@@ -562,7 +562,8 @@ class ModuleIndexer(object):
 
                     # remove the people who want to be ignored
                     if best_match in self.botmeta['files']:
-                        if 'ignored' in self.botmeta['files'][best_match]:
+                        if isinstance(self.botmeta['files'][best_match], dict) and \
+                                'ignored' in self.botmeta['files'][best_match]:
                             ignored = self.botmeta['files'][best_match]['ignored']
                             for xig in ignored:
                                 if xig in self.modules[k]['maintainers']:


### PR DESCRIPTION
```
2017-09-11 18:31:29,897 DEBUG ratelimited call #1 [<class 'ansibullbot.wrappers.ghapiwrapper.RepoWrapper'>] [get_repo] [4963]
2017-09-11 18:31:29,897 INFO getting issue objs for ansible/ansible-modules-extras
2017-09-11 18:31:29,899 DEBUG ansible/ansible-modules-extras issues pagecount:0 nodecount: 0
2017-09-11 18:31:29,900 INFO Starting new HTTPS connection (1): api.github.com
2017-09-11 18:31:30,008 DEBUG "POST /graphql HTTP/1.1" 200 None
2017-09-11 18:31:30,012 DEBUG ansible/ansible-modules-extras pullRequests pagecount:0 nodecount: 0
2017-09-11 18:31:30,013 INFO Starting new HTTPS connection (1): api.github.com
2017-09-11 18:31:30,194 DEBUG "POST /graphql HTTP/1.1" 200 None
2017-09-11 18:31:30,197 INFO 0 known numbers
2017-09-11 18:31:30,197 ERROR list index out of range
2017-09-11 18:31:30,197 ERROR Uncaught exception
Traceback (most recent call last):
  File "/home/ansibot/ansibullbot/triage_ansible.py", line 137, in <module>
    main()
  File "/home/ansibot/ansibullbot/triage_ansible.py", line 133, in main
    AnsibleTriage(args).start()
  File "/home/ansibot/ansibullbot/ansibullbot/triagers/defaulttriager.py", line 218, in start
    self.loop()
  File "/home/ansibot/ansibullbot/ansibullbot/triagers/defaulttriager.py", line 347, in loop
    self.run()
  File "/home/ansibot/ansibullbot/ansibullbot/triagers/ansible.py", line 314, in run
    self.collect_repos()
  File "/home/ansibot/ansibullbot/ansibullbot/triagers/ansible.py", line 1490, in collect_repos
    self._collect_repo(repo)
  File "/home/ansibot/ansibullbot/ansibullbot/decorators/github.py", line 175, in inner
    raise Exception('no data in exception')
```