### PR TITLE
Fix 'best match' in 'ModuleIndexer': avoid to mix maintainers

### DIFF
--- a/ansibullbot/parsers/botmetadata.py
+++ b/ansibullbot/parsers/botmetadata.py
@@ -92,9 +92,12 @@ class BotMetadataParser(object):
         # fix the macro'ized file keys
         ydata = fix_keys(ydata)
 
-        # convert string vals to a maintainers key in a dict
         for k,v in ydata['files'].items():
-            if isinstance(v, (str, unicode)):
+            if v is None:
+                # convert empty val in dict
+                ydata['files'][k] = {}
+            elif isinstance(v, (str, unicode)):
+                # convert string vals to a maintainers key in a dict
                 ydata['files'][k] = {
                     'maintainers': v
                 }

--- a/ansibullbot/parsers/botmetadata.py
+++ b/ansibullbot/parsers/botmetadata.py
@@ -109,6 +109,8 @@ class BotMetadataParser(object):
                         if 'maintainers' not in files[child]:
                             files[child]['maintainers'] = []
 
+                        files[child]['maintainers_keys'].append(top)
+
                         for maintainer in top_maintainers:
                             if maintainer not in files[child]['maintainers']:
                                 files[child]['maintainers'].append(maintainer)
@@ -134,6 +136,8 @@ class BotMetadataParser(object):
                 ydata['files'][k] = {
                     'maintainers': v
                 }
+
+            ydata['files'][k]['maintainers_keys'] = [k]
 
         # replace macros in files section
         ydata = fix_lists(ydata)

--- a/ansibullbot/parsers/botmetadata.py
+++ b/ansibullbot/parsers/botmetadata.py
@@ -1,7 +1,10 @@
 #!/usr/bin/env python
 
-import yaml
+import os
+
 from string import Template
+
+import yaml
 
 
 class BotMetadataParser(object):
@@ -49,6 +52,12 @@ class BotMetadataParser(object):
                 data['files'][newkey] = data['files'][x]
                 data['files'].pop(x, None)
 
+            paths = data['files'].keys()
+            for p in paths:
+                normpath = os.path.normpath(p)
+                if p != normpath:
+                    metadata = data['files'].pop(p)
+                    data['files'][normpath] = metadata
             return data
 
         def extend_labels(data):

--- a/ansibullbot/triagers/ansible.py
+++ b/ansibullbot/triagers/ansible.py
@@ -1668,9 +1668,6 @@ class AnsibleTriage(DefaultTriager):
 
         self.meta['submitter'] = iw.submitter
 
-        # clear maintainers
-        self.maintainers = []
-
         # extract template data
         self.template_data = iw.get_template_data()
 

--- a/ansibullbot/utils/moduletools.py
+++ b/ansibullbot/utils/moduletools.py
@@ -552,11 +552,9 @@ class ModuleIndexer(object):
                             self.modules[k]['maintainers'].append(maintainer)
 
                     # remove the people who want to be ignored
-                    if 'ignored' in self.botmeta['files'][best_match]:
-                        ignored = self.botmeta['files'][best_match]['ignored']
-                        for xig in ignored:
-                            if xig in self.modules[k]['maintainers']:
-                                self.modules[k]['maintainers'].remove(xig)
+                    for ignored in self.botmeta['files'][best_match].get('ignored', []):
+                        if ignored in self.modules[k]['maintainers']:
+                            self.modules[k]['maintainers'].remove(ignored)
 
             # save a pristine copy so that higher level code can still use it
             self.modules[k]['maintainers'] = sorted(set(self.modules[k]['maintainers']))

--- a/ansibullbot/utils/moduletools.py
+++ b/ansibullbot/utils/moduletools.py
@@ -515,7 +515,7 @@ class ModuleIndexer(object):
 
         mkeys = self.botmeta['files'].keys()
         for k,v in self.modules.iteritems():
-            if not v['filepath']:
+            if k == 'meta':
                 continue
 
             if k in self.botmeta['files']:

--- a/ansibullbot/utils/moduletools.py
+++ b/ansibullbot/utils/moduletools.py
@@ -30,7 +30,7 @@ class ModuleIndexer(object):
         'fulltopic': None,
         'maintainers': [],
         '_maintainers': [],
-        'maintainers_key': None,
+        'maintainers_keys': None,
         'metadata': {},
         'repo_filename': None,
         'repository': 'ansible',
@@ -520,9 +520,9 @@ class ModuleIndexer(object):
                 continue
 
             if k in self.botmeta['files']:
-
-                # should this also inherit from higher up?
-                self.modules[k]['maintainers_key'] = k
+                # There are metadata in .github/BOTMETA.yml for this file
+                # copy maintainers_keys
+                self.modules[k]['maintainers_keys'] = self.botmeta['files'][k]['maintainers_keys'][:]
 
                 if self.botmeta['files'][k]:
                     if self.botmeta['files'][k].get('maintainers'):
@@ -538,7 +538,7 @@ class ModuleIndexer(object):
                                 self.modules[k]['maintainers'].remove(x)
 
             else:
-
+                # There isn't metadata in .github/BOTMETA.yml for this file
                 best_match = None
                 for mkey in mkeys:
                     if v['filepath'].startswith(mkey):
@@ -548,7 +548,7 @@ class ModuleIndexer(object):
                         if len(mkey) > len(best_match):
                             best_match = mkey
                 if best_match:
-                    self.modules[k]['maintainers_key'] = best_match
+                    self.modules[k]['maintainers_keys'] = [best_match]
                     for maintainer in self.botmeta['files'][best_match].get('maintainers', []):
                         if maintainer not in self.modules[k]['maintainers']:
                             self.modules[k]['maintainers'].append(maintainer)

--- a/ansibullbot/utils/moduletools.py
+++ b/ansibullbot/utils/moduletools.py
@@ -268,8 +268,7 @@ class ModuleIndexer(object):
             else:
                 mdict['deprecated_filename'] = mdict['repo_filename']
 
-            mkey = mdict['filepath']
-            self.modules[mkey] = mdict
+            self.modules[filepath] = mdict
 
         # meta is a special module
         self.modules['meta'] = copy.deepcopy(self.EMPTY_MODULE)

--- a/ansibullbot/utils/moduletools.py
+++ b/ansibullbot/utils/moduletools.py
@@ -562,8 +562,7 @@ class ModuleIndexer(object):
 
                     # remove the people who want to be ignored
                     if best_match in self.botmeta['files']:
-                        if isinstance(self.botmeta['files'][best_match], dict) and \
-                                'ignored' in self.botmeta['files'][best_match]:
+                        if 'ignored' in self.botmeta['files'][best_match]:
                             ignored = self.botmeta['files'][best_match]['ignored']
                             for xig in ignored:
                                 if xig in self.modules[k]['maintainers']:

--- a/ansibullbot/utils/moduletools.py
+++ b/ansibullbot/utils/moduletools.py
@@ -89,11 +89,10 @@ class ModuleIndexer(object):
         # reshape data to the old format
         self.maintainers = {}
         for k,v in self.botmeta['files'].items():
-            fp = k.replace('lib/ansible/modules/', '')
             if isinstance(v, dict):
-                self.maintainers[fp] = v.get('maintainers', [])
+                self.maintainers[k] = v.get('maintainers', [])
             else:
-                self.maintainers[fp] = []
+                self.maintainers[k] = []
 
         # load the modules
         logging.info('loading modules')
@@ -548,14 +547,13 @@ class ModuleIndexer(object):
 
                 best_match = None
                 for mkey in mkeys:
-                    if mkey in v['filepath']:
+                    if v['filepath'].startswith(mkey):
                         if not best_match:
                             best_match = mkey
                             continue
                         if len(mkey) > len(best_match):
                             best_match = mkey
                 if best_match:
-
                     self.modules[k]['maintainers_key'] = best_match
                     self.modules[k]['maintainers'] += \
                         sorted(set(self.maintainers[best_match]))

--- a/ansibullbot/utils/moduletools.py
+++ b/ansibullbot/utils/moduletools.py
@@ -528,8 +528,7 @@ class ModuleIndexer(object):
                         self.modules[k]['maintainers'] = \
                             self.botmeta['files'][k]['maintainers']
 
-                # remove the people who want to be ignored
-                if self.botmeta['files'][k]:
+                    # remove the people who want to be ignored
                     if 'ignored' in self.botmeta['files'][k]:
                         ignored = self.botmeta['files'][k]['ignored']
                         for x in ignored:
@@ -553,12 +552,11 @@ class ModuleIndexer(object):
                             self.modules[k]['maintainers'].append(maintainer)
 
                     # remove the people who want to be ignored
-                    if best_match in self.botmeta['files']:
-                        if 'ignored' in self.botmeta['files'][best_match]:
-                            ignored = self.botmeta['files'][best_match]['ignored']
-                            for xig in ignored:
-                                if xig in self.modules[k]['maintainers']:
-                                    self.modules[k]['maintainers'].remove(xig)
+                    if 'ignored' in self.botmeta['files'][best_match]:
+                        ignored = self.botmeta['files'][best_match]['ignored']
+                        for xig in ignored:
+                            if xig in self.modules[k]['maintainers']:
+                                self.modules[k]['maintainers'].remove(xig)
 
             # save a pristine copy so that higher level code can still use it
             self.modules[k]['maintainers'] = sorted(set(self.modules[k]['maintainers']))

--- a/ansibullbot/utils/moduletools.py
+++ b/ansibullbot/utils/moduletools.py
@@ -513,7 +513,7 @@ class ModuleIndexer(object):
             self.modules[k]['maintainers'] = \
                 sorted(set(self.modules[k]['maintainers']))
 
-        mkeys = self.botmeta['files'].keys()
+        metadata = self.botmeta['files'].keys()
         for k,v in self.modules.iteritems():
             if k == 'meta':
                 continue
@@ -539,7 +539,7 @@ class ModuleIndexer(object):
             else:
                 # There isn't metadata in .github/BOTMETA.yml for this file
                 best_match = None
-                for mkey in mkeys:
+                for mkey in metadata:
                     if v['filepath'].startswith(mkey):
                         if not best_match:
                             best_match = mkey

--- a/ansibullbot/utils/moduletools.py
+++ b/ansibullbot/utils/moduletools.py
@@ -524,9 +524,10 @@ class ModuleIndexer(object):
                 self.modules[k]['maintainers_keys'] = self.botmeta['files'][k]['maintainers_keys'][:]
 
                 if self.botmeta['files'][k]:
-                    if self.botmeta['files'][k].get('maintainers'):
-                        self.modules[k]['maintainers'] = \
-                            self.botmeta['files'][k]['maintainers']
+                    maintainers = self.botmeta['files'][k].get('maintainers', [])
+                    for maintainer in maintainers:
+                        if maintainer not in self.modules[k]['maintainers']:
+                            self.modules[k]['maintainers'].append(maintainer)
 
                     # remove the people who want to be ignored
                     if 'ignored' in self.botmeta['files'][k]:

--- a/tests/unit/parsers/test_bot_metadata_parser.py
+++ b/tests/unit/parsers/test_bot_metadata_parser.py
@@ -73,13 +73,13 @@ class TestBotMetadataParserEx1(TestBotMetaIndexerBase):
 
         assert 'macros' in data
         assert 'files' in data
-        assert 'lib/ansible/cli/galaxy/' in data['files']
+        assert 'lib/ansible/cli/galaxy' in data['files']
         assert 'lib/ansible/cli/vault.py' in data['files']
-        assert 'lib/ansible/parsing/vault/' in data['files']
-        assert 'lib/ansible/foobar/' in data['files']
+        assert 'lib/ansible/parsing/vault' in data['files']
+        assert 'lib/ansible/foobar' in data['files']
 
         self.assertEqual(
-            data['files']['lib/ansible/foobar/']['labels'],
+            data['files']['lib/ansible/foobar']['labels'],
             ['ansible', 'bar', 'foo', 'foobar', 'lib']
         )
 
@@ -103,7 +103,7 @@ class TestBotMetadataParserEx1(TestBotMetaIndexerBase):
             ['one', 'line', 'at', 'a', 'time']
         )
 
-        self.assertEqual(dict, type(data['files']['packaging/']))
+        self.assertEqual(dict, type(data['files']['packaging']))
 
 class TestBotMetadataParserFileExample1(TestBotMetaIndexerBase):
     def runTest(self):

--- a/tests/unit/parsers/test_bot_metadata_parser.py
+++ b/tests/unit/parsers/test_bot_metadata_parser.py
@@ -49,6 +49,8 @@ files:
             - bar
     # using macro for the key and maintainers
     $modules/x/y: $team_galaxy
+
+    packaging/:
 """
 
 
@@ -100,6 +102,8 @@ class TestBotMetadataParserEx1(TestBotMetaIndexerBase):
             data['macros']['team_oneline'],
             ['one', 'line', 'at', 'a', 'time']
         )
+
+        self.assertEqual(dict, type(data['files']['packaging/']))
 
 class TestBotMetadataParserFileExample1(TestBotMetaIndexerBase):
     def runTest(self):

--- a/tests/unit/utils/test_module_indexer.py
+++ b/tests/unit/utils/test_module_indexer.py
@@ -64,7 +64,7 @@ class TestModuleIndexer(TestCase):
               maintainers: csim
         """
 
-        filepath = 'packaging/apt.py'
+        filepath = 'lib/ansible/modules/packaging/apt.py'
         indexer = run(textwrap.dedent(BOTMETA), ['Hubert'], filepath)
         self.assertEqual(len(indexer.modules), 1)  # ensure only fake data are loaded
         self.assertEqual(indexer.modules[filepath]['maintainers'], ['Hubert'])
@@ -88,11 +88,11 @@ class TestModuleIndexer(TestCase):
             $modules/foo/bar: jim
         """
 
-        filepath = 'foo/bar/baz.py'
+        filepath = 'lib/ansible/modules/foo/bar/baz.py'
         indexer = run(textwrap.dedent(BOTMETA), ['bob'], filepath)
         self.assertEqual(len(indexer.modules), 1)  # ensure only fake data are loaded
         self.assertEqual(set(indexer.modules[filepath]['maintainers']), set(['bob', 'jim']))  # both
-        self.assertEqual(indexer.modules[filepath]['maintainers_key'], 'foo/bar')
+        self.assertEqual(indexer.modules[filepath]['maintainers_key'], 'lib/ansible/modules/foo/bar')
 
     def test_maintainers_dont_inherit_from_directory_maintainers(self):
         """module maintainers don't inherit from parent directory maintainers (both defined in BOTMETA)
@@ -113,8 +113,8 @@ class TestModuleIndexer(TestCase):
             $modules/foo/bar/baz.py: bob
         """
 
-        filepath = 'foo/bar/baz.py'
+        filepath = 'lib/ansible/modules/foo/bar/baz.py'
         indexer = run(textwrap.dedent(BOTMETA), [], filepath)
         self.assertEqual(len(indexer.modules), 1)  # ensure only fake data are loaded
         self.assertEqual(set(indexer.modules[filepath]['maintainers']), set(['bob']))  # only bob, not jim
-        self.assertEqual(indexer.modules[filepath]['maintainers_key'], 'foo/bar/baz.py')
+        self.assertEqual(indexer.modules[filepath]['maintainers_key'], 'lib/ansible/modules/foo/bar/baz.py')

--- a/tests/unit/utils/test_module_indexer.py
+++ b/tests/unit/utils/test_module_indexer.py
@@ -1,7 +1,9 @@
 #!/usr/bin/env python
 
 import copy
+import os
 import six
+import textwrap
 from unittest import TestCase
 
 six.add_move(six.MovedModule('mock', 'mock', 'unittest.mock'))
@@ -9,39 +11,110 @@ from six.moves import mock
 
 from ansibullbot.utils.moduletools import ModuleIndexer
 
-METADATA = """
----
-macros:
-    team_green:
-      - larry
-      - cow
-    modules: lib/ansible/modules
-files:
 
-    packaging/:
-      maintainers: csim
-"""
+def run(BOTMETA, authors, filepath):
 
-def set_modules(self):
-    mdict = copy.deepcopy(ModuleIndexer.EMPTY_MODULE)
-    mdict['filename'] = 'apt.py'
-    mdict['filepath'] = 'lib/ansible/modules/packaging/apt.py'
-    self.modules[mdict['filepath']] = mdict
+    def set_modules(self):
+        '''list modules from filesystem'''
+        m = copy.deepcopy(ModuleIndexer.EMPTY_MODULE)
+        m['filename'] = os.path.basename(filepath)
+        m['filepath'] = filepath
+        self.modules[m['filepath']] = m
 
-def set_authors(self, mfile):
-    assert mfile.endswith('lib/ansible/modules/packaging/apt.py')
-    return ['Hubert']
+    def set_authors(self, mfile):
+        '''set authors from module source code: 'author' field in DOCUMENTATION metadata'''
+        if mfile.endswith(filepath):
+            return authors
+        else:
+            assert False
 
-class TestModuleIndexer(TestCase):
     @mock.patch.object(ModuleIndexer, 'update')
     @mock.patch.object(ModuleIndexer, 'get_module_authors', side_effect=set_authors, autospec=True)
     @mock.patch.object(ModuleIndexer, 'get_ansible_modules', side_effect=set_modules, autospec=True)
-    @mock.patch.object(ModuleIndexer, 'get_file_content', return_value=METADATA)
-    def test_maintainers(self, m_update, m_authors, m_modules, m_content):
+    @mock.patch.object(ModuleIndexer, 'get_file_content', return_value=BOTMETA)
+    def indexer(m_update, m_authors, m_modules, m_content):
         indexer = ModuleIndexer()
         indexer.parse_metadata()
         indexer.set_maintainers()
-        self.assertEqual(len(indexer.modules), 1)
-        mfile = 'lib/ansible/modules/packaging/apt.py'
-        self.assertEqual(indexer.modules[mfile]['maintainers_key'], None)
-        self.assertEqual(indexer.modules[mfile]['maintainers'], ['Hubert'])
+        return indexer
+
+    return indexer()
+
+
+class TestModuleIndexer(TestCase):
+
+    def test_maintainers(self):
+        """maintainers don't get mix up
+
+        - author is defined in 'author' field of 'DOCUMENTATION' module metadata ('Hubert')
+        - module path not in BOTMETA ('lib/ansible/modules/packaging/apt.py')
+        - one another directory with one maintainer in BOTMETA, directory name
+          is included in module path but is unrelated ('packaging/')
+        """
+
+        BOTMETA = """
+        ---
+        macros:
+            team_green:
+              - larry
+              - cow
+            modules: lib/ansible/modules
+        files:
+            packaging/:
+              maintainers: csim
+        """
+
+        filepath = 'packaging/apt.py'
+        indexer = run(textwrap.dedent(BOTMETA), ['Hubert'], filepath)
+        self.assertEqual(len(indexer.modules), 1)  # ensure only fake data are loaded
+        self.assertEqual(indexer.modules[filepath]['maintainers'], ['Hubert'])
+        self.assertEqual(indexer.modules[filepath]['maintainers_key'], None)
+
+    def test_module_authors_inherit_from_directory_maintainers(self):
+        """ authors defined in module metadata inherit from directory maintainers specified in BOTMETA
+
+        - author is defined in 'author' field of 'DOCUMENTATION' module metadata ('bob')
+        - module path not in BOTMETA ('lib/ansible/modules/foo/bar/baz.py')
+        - one parent directory in BOTMETA with one maintainer ('lib/ansible/modules/foo/bar')
+        """
+        BOTMETA = """
+        ---
+        macros:
+            team_green:
+              - larry
+              - cow
+            modules: lib/ansible/modules
+        files:
+            $modules/foo/bar: jim
+        """
+
+        filepath = 'foo/bar/baz.py'
+        indexer = run(textwrap.dedent(BOTMETA), ['bob'], filepath)
+        self.assertEqual(len(indexer.modules), 1)  # ensure only fake data are loaded
+        self.assertEqual(set(indexer.modules[filepath]['maintainers']), set(['bob', 'jim']))  # both
+        self.assertEqual(indexer.modules[filepath]['maintainers_key'], 'foo/bar')
+
+    def test_maintainers_dont_inherit_from_directory_maintainers(self):
+        """module maintainers don't inherit from parent directory maintainers (both defined in BOTMETA)
+
+        - author isn't defined in 'author' field of 'DOCUMENTATION' module metadata
+        - module path in BOTMETA ('lib/ansible/modules/foo/bar/baz.py')
+        - one parent directory in BOTMETA with one maintainer ('lib/ansible/modules/foo/bar')
+        """
+        BOTMETA = """
+        ---
+        macros:
+            team_green:
+              - larry
+              - cow
+            modules: lib/ansible/modules
+        files:
+            $modules/foo/bar: jim
+            $modules/foo/bar/baz.py: bob
+        """
+
+        filepath = 'foo/bar/baz.py'
+        indexer = run(textwrap.dedent(BOTMETA), [], filepath)
+        self.assertEqual(len(indexer.modules), 1)  # ensure only fake data are loaded
+        self.assertEqual(set(indexer.modules[filepath]['maintainers']), set(['bob']))  # only bob, not jim
+        self.assertEqual(indexer.modules[filepath]['maintainers_key'], 'foo/bar/baz.py')

--- a/tests/unit/utils/test_module_indexer.py
+++ b/tests/unit/utils/test_module_indexer.py
@@ -12,21 +12,36 @@ from six.moves import mock
 from ansibullbot.utils.moduletools import ModuleIndexer
 
 
-def run(BOTMETA, authors, filepath):
+def run(BOTMETA, filepaths):
+    """Create and test ModuleIndexer
+
+    1. parse BOTMETA metadata
+    2. list source code paths (filepaths keys)
+    3. fetch authors from source code content (filepaths values)
+
+    filepaths = {
+        'lib/ansible/modules/foo/bar/baz.py': None, # no author in source code
+        'lib/ansible/modules/foo2/bar2/baz.py': ['author1', 'author2'],
+    }
+    """
 
     def set_modules(self):
         '''list modules from filesystem'''
-        m = copy.deepcopy(ModuleIndexer.EMPTY_MODULE)
-        m['filename'] = os.path.basename(filepath)
-        m['filepath'] = filepath
-        self.modules[m['filepath']] = m
+        for filepath in filepaths.keys():
+            m = copy.deepcopy(ModuleIndexer.EMPTY_MODULE)
+            m['filename'] = os.path.basename(filepath)
+            m['filepath'] = filepath
+            self.modules[filepath] = m
 
     def set_authors(self, mfile):
         '''set authors from module source code: 'author' field in DOCUMENTATION metadata'''
-        if mfile.endswith(filepath):
-            return authors
-        else:
-            assert False
+        for (filepath, authors) in filepaths.items():
+            if mfile.endswith(filepath):
+                if not authors:
+                    return []
+                else:
+                    return authors
+        assert False
 
     @mock.patch.object(ModuleIndexer, 'update')
     @mock.patch.object(ModuleIndexer, 'get_module_authors', side_effect=set_authors, autospec=True)
@@ -42,6 +57,32 @@ def run(BOTMETA, authors, filepath):
 
 
 class TestModuleIndexer(TestCase):
+    BOTMETA = """
+    ---
+    macros:
+        team_green:
+          - larry
+          - cow
+        modules: lib/ansible/modules
+    files:
+        # Simplest test
+        $modules/foo/bar: jim
+        $modules/foo/bar/baz.py: bob
+
+        # Check path normalization
+        $modules/foo2/bar2/: jim
+        $modules/foo2/bar2/baz.py: bob
+
+        # Check that only full paths match
+        $modules/bar/foo: csim
+        $modules/bar/foofoo.py: uolip
+
+        # Check with two parent directories
+        $modules/baz:
+            maintainers: [ZaZa, Loulou]
+        $modules/baz/test: jim
+        $modules/baz/test/code.py: bob
+    """
 
     def test_maintainers(self):
         """maintainers don't get mix up
@@ -63,15 +104,29 @@ class TestModuleIndexer(TestCase):
             packaging/:
               maintainers: csim
         """
+        expected = {
+            'packaging': {
+                'maintainers': ['csim'],
+                'maintainers_keys': ['packaging'],
+                'labels': ['packaging'],
+            }
+        }
 
         filepath = 'lib/ansible/modules/packaging/apt.py'
-        indexer = run(textwrap.dedent(BOTMETA), ['Hubert'], filepath)
+        filepaths = {filepath: ['Hubert']}
+        indexer = run(textwrap.dedent(BOTMETA), filepaths)
+
+        self.assertEqual(indexer.botmeta['files'], expected)
+
         self.assertEqual(len(indexer.modules), 1)  # ensure only fake data are loaded
         self.assertEqual(indexer.modules[filepath]['maintainers'], ['Hubert'])
-        self.assertEqual(indexer.modules[filepath]['maintainers_key'], None)
+        self.assertFalse(indexer.modules[filepath]['maintainers_keys'])
 
     def test_module_authors_inherit_from_directory_maintainers(self):
-        """ authors defined in module metadata inherit from directory maintainers specified in BOTMETA
+        """Check maintainers
+
+        Authors defined in 'author' field of 'DOCUMENTATION' module metadata inherit from
+        directory maintainers specified in BOTMETA.
 
         - author is defined in 'author' field of 'DOCUMENTATION' module metadata ('bob')
         - module path not in BOTMETA ('lib/ansible/modules/foo/bar/baz.py')
@@ -88,33 +143,99 @@ class TestModuleIndexer(TestCase):
             $modules/foo/bar: jim
         """
 
+        expected = {
+            'lib/ansible/modules/foo/bar': {
+                'labels': sorted(['lib', 'ansible', 'modules', 'foo', 'bar']),
+                'maintainers': ['jim'],
+                'maintainers_keys': ['lib/ansible/modules/foo/bar'],
+            }
+        }
+
         filepath = 'lib/ansible/modules/foo/bar/baz.py'
-        indexer = run(textwrap.dedent(BOTMETA), ['bob'], filepath)
+        filepaths = {filepath: ['bob']}
+        indexer = run(textwrap.dedent(BOTMETA), filepaths)
+
+        self.assertEqual(indexer.botmeta['files'], expected)
+
         self.assertEqual(len(indexer.modules), 1)  # ensure only fake data are loaded
         self.assertEqual(set(indexer.modules[filepath]['maintainers']), set(['bob', 'jim']))  # both
-        self.assertEqual(indexer.modules[filepath]['maintainers_key'], 'lib/ansible/modules/foo/bar')
+        self.assertEqual(indexer.modules[filepath]['maintainers_keys'], ['lib/ansible/modules/foo/bar'])
 
-    def test_maintainers_dont_inherit_from_directory_maintainers(self):
-        """module maintainers don't inherit from parent directory maintainers (both defined in BOTMETA)
+    def test_maintainers_inherit_from_directory_maintainers(self):
+        """Check maintainers inheritance
 
-        - author isn't defined in 'author' field of 'DOCUMENTATION' module metadata
-        - module path in BOTMETA ('lib/ansible/modules/foo/bar/baz.py')
-        - one parent directory in BOTMETA with one maintainer ('lib/ansible/modules/foo/bar')
-        """
-        BOTMETA = """
-        ---
-        macros:
-            team_green:
-              - larry
-              - cow
-            modules: lib/ansible/modules
-        files:
-            $modules/foo/bar: jim
-            $modules/foo/bar/baz.py: bob
+        No author defined in 'author' field of 'DOCUMENTATION' module metadata.
         """
 
-        filepath = 'lib/ansible/modules/foo/bar/baz.py'
-        indexer = run(textwrap.dedent(BOTMETA), [], filepath)
-        self.assertEqual(len(indexer.modules), 1)  # ensure only fake data are loaded
-        self.assertEqual(set(indexer.modules[filepath]['maintainers']), set(['bob']))  # only bob, not jim
-        self.assertEqual(indexer.modules[filepath]['maintainers_key'], 'lib/ansible/modules/foo/bar/baz.py')
+        filepaths = {
+            'lib/ansible/modules/foo/bar/baz.py': None,
+            'lib/ansible/modules/foo2/bar2/baz.py': None,
+            'lib/ansible/modules/bar/foofoo.py': None,
+            'lib/ansible/modules/baz/test/code.py': None,
+        }
+
+        expected = {}
+        key = 'lib/ansible/modules/foo/bar'
+        expected[key] = {
+            'maintainers': ['jim'],
+            'maintainers_keys': [key],
+        }
+        key = 'lib/ansible/modules/foo/bar/baz.py'
+        expected[key] = {
+            'maintainers': ['bob', 'jim'],
+            'maintainers_keys': ['lib/ansible/modules/foo/bar', key],
+        }
+        key = 'lib/ansible/modules/foo2/bar2'
+        expected[key] = {
+            'maintainers': ['jim'],
+            'maintainers_keys': [key],
+        }
+        key = 'lib/ansible/modules/foo2/bar2/baz.py'
+        expected[key] = {
+            'maintainers': ['bob', 'jim'],
+            'maintainers_keys': ['lib/ansible/modules/foo2/bar2', key],
+        }
+        key = 'lib/ansible/modules/bar/foo'
+        expected[key] = {
+            'maintainers': ['csim'],
+            'maintainers_keys': [key],
+        }
+
+        key = 'lib/ansible/modules/bar/foofoo.py'
+        expected[key] = {
+            'maintainers': ['uolip'],
+            'maintainers_keys': [key],
+        }
+
+        key = 'lib/ansible/modules/baz'
+        expected[key] = {
+            'maintainers': ['Loulou', 'ZaZa'],
+            'maintainers_keys': [key],
+        }
+
+        key = 'lib/ansible/modules/baz/test'
+        expected[key] = {
+            'maintainers': ['Loulou', 'jim', 'ZaZa'],
+            'maintainers_keys': ['lib/ansible/modules/baz', key],
+        }
+
+        key = 'lib/ansible/modules/baz/test/code.py'
+        expected[key] = {
+            'maintainers': ['Loulou', 'bob', 'jim', 'ZaZa'],
+            'maintainers_keys': ['lib/ansible/modules/baz', 'lib/ansible/modules/baz/test', key],
+        }
+
+        indexer = run(textwrap.dedent(self.BOTMETA), filepaths)
+
+        self.assertEqual(len(indexer.modules), len(filepaths))  # ensure only fake data are loaded
+
+        for k in expected:
+            # BOTMETA and modules have identical maintainers since there is no authors
+            # defined in source code
+            self.assertEqual(sorted(indexer.botmeta['files'][k]['maintainers_keys']),sorted(expected[k]['maintainers_keys']))
+            self.assertEqual(sorted(indexer.botmeta['files'][k]['maintainers']), sorted(expected[k]['maintainers']))
+
+        for k in filepaths:
+            self.assertEqual(sorted(indexer.modules[k]['maintainers_keys']),sorted(expected[k]['maintainers_keys']))
+            self.assertEqual(sorted(indexer.modules[k]['maintainers']), sorted(expected[k]['maintainers']))
+

--- a/tests/unit/utils/test_module_indexer.py
+++ b/tests/unit/utils/test_module_indexer.py
@@ -239,3 +239,23 @@ class TestModuleIndexer(TestCase):
             self.assertEqual(sorted(indexer.modules[k]['maintainers_keys']),sorted(expected[k]['maintainers_keys']))
             self.assertEqual(sorted(indexer.modules[k]['maintainers']), sorted(expected[k]['maintainers']))
 
+    def test_authors_not_omitted_if_entry_in_BOTMETA(self):
+        """Check that authors aren't omitted when metadata are overidden in BOTMETA
+
+        Ensure that authors defined in 'author' field of 'DOCUMENTATION' module
+        metadata aren't omitted when there is a matching entry in BOTMETA.yml.
+
+        Same BOTMETA.yml, but now authors are defined in 'author' field of
+        'DOCUMENTATION' module metadata.
+        """
+
+        filepaths = {
+            'lib/ansible/modules/baz/test/code.py': ['Louise'],
+        }
+
+        expected_maintainers = sorted(['Loulou', 'bob', 'jim', 'ZaZa', 'Louise'])
+
+        indexer = run(textwrap.dedent(self.BOTMETA), filepaths)
+
+        self.assertEqual(len(indexer.modules), len(filepaths))  # ensure only fake data are loaded
+        self.assertEqual(sorted(indexer.modules['lib/ansible/modules/baz/test/code.py']['maintainers']), expected_maintainers)

--- a/tests/unit/utils/test_module_indexer.py
+++ b/tests/unit/utils/test_module_indexer.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python
+
+import copy
+import six
+from unittest import TestCase
+
+six.add_move(six.MovedModule('mock', 'mock', 'unittest.mock'))
+from six.moves import mock
+
+from ansibullbot.utils.moduletools import ModuleIndexer
+
+METADATA = """
+---
+macros:
+    team_green:
+      - larry
+      - cow
+    modules: lib/ansible/modules
+files:
+
+    packaging/:
+      maintainers: csim
+"""
+
+def set_modules(self):
+    mdict = copy.deepcopy(ModuleIndexer.EMPTY_MODULE)
+    mdict['filename'] = 'apt.py'
+    mdict['filepath'] = 'lib/ansible/modules/packaging/apt.py'
+    self.modules[mdict['filepath']] = mdict
+
+def set_authors(self, mfile):
+    assert mfile.endswith('lib/ansible/modules/packaging/apt.py')
+    return ['Hubert']
+
+class TestModuleIndexer(TestCase):
+    @mock.patch.object(ModuleIndexer, 'update')
+    @mock.patch.object(ModuleIndexer, 'get_module_authors', side_effect=set_authors, autospec=True)
+    @mock.patch.object(ModuleIndexer, 'get_ansible_modules', side_effect=set_modules, autospec=True)
+    @mock.patch.object(ModuleIndexer, 'get_file_content', return_value=METADATA)
+    def test_maintainers(self, m_update, m_authors, m_modules, m_content):
+        indexer = ModuleIndexer()
+        indexer.parse_metadata()
+        indexer.set_maintainers()
+        self.assertEqual(len(indexer.modules), 1)
+        mfile = 'lib/ansible/modules/packaging/apt.py'
+        self.assertEqual(indexer.modules[mfile]['maintainers_key'], None)
+        self.assertEqual(indexer.modules[mfile]['maintainers'], ['Hubert'])

--- a/tests/unit/utils/test_module_indexer.py
+++ b/tests/unit/utils/test_module_indexer.py
@@ -316,10 +316,11 @@ class TestModuleIndexer(TestCase):
         self.assertEqual(sorted(indexer.modules['lib/ansible/modules/baz/test/code4.py']['maintainers']), sorted(['ElsA', 'Oliver']))
 
     def test_ignored_author_in_parent_dir(self):
-        """Check that author ignored in BOTMETA in a parent directory are not removed
+        """Check that author ignored in BOTMETA in a parent directory are removed
 
-        Some authors defined in 'author' field of 'DOCUMENTATION' module
-        metadata but ignored in a parent directory entry in BOTMETA.
+        Some authors are defined in 'author' field of 'DOCUMENTATION' module
+        metadata and ignored in a parent directory entry in BOTMETA: ignored
+        authors aren't maintainers.
         """
         BOTMETA = """
         ---
@@ -338,7 +339,7 @@ class TestModuleIndexer(TestCase):
             'lib/ansible/modules/baz/test/code.py': ['Louise', 'Oliver'],
         }
 
-        expected_maintainers = sorted(['ElsA', 'bob', 'Louise', 'Oliver'])  # Oliver here
+        expected_maintainers = sorted(['ElsA', 'bob', 'Louise'])  # Oliver not here
 
         indexer = run(textwrap.dedent(BOTMETA), filepaths)
 


### PR DESCRIPTION
When:

1. a module path without an entry in `BOTMETA.yml` (for example `lib/ansible/modules/packaging/os/xbps.py`)
2. contains another unrelated entry present in `BOTMETA.yml` (for example `packaging/`)
3. then maintainers of the `BOTMETA.yml` entry are added to module maintainers

This pull request:
- add unit test
- improve match: fix this issue