### PR TITLE
Fix pickle path for issues

### DIFF
--- a/ansibullbot/wrappers/ghapiwrapper.py
+++ b/ansibullbot/wrappers/ghapiwrapper.py
@@ -44,8 +44,8 @@ class RepoWrapper(object):
         self.repo_path = repo_path
 
         self.cachedir = os.path.expanduser(cachedir)
-        self.cachefile = os.path.join(self.cachedir, repo_path)
-        self.cachefile = '%s/repo.pickle' % self.cachefile
+        self.cachedir = os.path.join(self.cachedir, repo_path)
+        self.cachefile = os.path.join(self.cachedir, 'repo.pickle')
 
         self.updated_at_previous = None
         self.updated = False


### PR DESCRIPTION
After running `python ./triage_ansible.py --dry-run --logfile /tmp/ansibot --daemonize`  over ~6 hours:
<pre>
$ find ~/.ansibullbot/cache -iname issues
.ansibullbot/cache/cmprescott/ansible-xml/issues
.ansibullbot/cache/ansible/ansible-modules-core/issues
.ansibullbot/cache/ansible/ansible/issues
.ansibullbot/cache/ansible/ansible-modules-extras/issues
</pre>

Closes #759