### PR TITLE
Fix test_template_extractor test_2

### DIFF
--- a/ansibullbot/utils/extractors.py
+++ b/ansibullbot/utils/extractors.py
@@ -193,7 +193,6 @@ def extract_template_data(body, issue_number=None, issue_class='issue', sections
         # remove pre-ceding and trailing newlines (AGAIN)
         v = v.strip()
 
-        # import epdb; epdb.st()
         # clean more on critical sections
         if 'step' not in k and 'result' not in k:
 

--- a/ansibullbot/utils/extractors.py
+++ b/ansibullbot/utils/extractors.py
@@ -302,14 +302,9 @@ def clean_bad_characters(raw_text, exclude=[]):
 
     # Don't remove characters passed in as an exclusion
     badchars = [x for x in badchars if x not in exclude]
-    if "It's" in raw_text:
-        import q; q(badchars)
 
     for bc in badchars:
         raw_text = raw_text.replace(bc, '')
-
-    if "It's" in raw_text:
-        import q; q(raw_text)
 
     return raw_text
 

--- a/tests/unit/utils/test_template_extractor.py
+++ b/tests/unit/utils/test_template_extractor.py
@@ -51,13 +51,11 @@ class TestTemplateExtraction(unittest.TestCase):
         assert tdata.get('component_raw') == 'widget module'
         assert tdata.get('summary') == 'the widget module does not work for me!!!'
 
-    # FIXME
-    '''
     def test_2(self):
         body = [
             '*** issue type ***:',
             '- Bug Report',
-            '*** componet name ***:',
+            '*** component name ***:',
             'widget module',
             '*** ansible version ***:',
             '1.9.x'
@@ -77,7 +75,6 @@ class TestTemplateExtraction(unittest.TestCase):
         assert tdata.get('component name') == 'widget'
         assert tdata.get('component_raw') == 'widget module'
         assert tdata.get('summary') == 'the widget module does not work for me!!!'
-    '''
 
     # https://github.com/ansible/ansibullbot/issues/359
     def test_3(self):

--- a/tests/unit/utils/test_template_extractor.py
+++ b/tests/unit/utils/test_template_extractor.py
@@ -133,3 +133,30 @@ class TestTemplateExtraction(unittest.TestCase):
         assert tdata.get('component name') == 'openssl_privatekey'
         assert tdata.get('component_raw') == 'Modules openssl_privatekey and openssl_publickey'
         assert tdata.get('summary') == 'the widget AND thingamig modules are broken!!!'
+
+
+    # Test optional Markdown header syntax
+    def test_5(self):
+        body = [
+            '#### ISSUE TYPE ####',
+            '- Bug Report',
+            '#### COMPONENT NAME ####',
+            'widget, thingamajig',
+            '#### ANSIBLE VERSION ####',
+            '1.9.x'
+            '#### SUMMARY ####',
+            'the widget AND thingamig modules are broken!!!'
+        ]
+        body = '\r\n'.join(body)
+        issue_number = 0
+        issue_class = 'issue'
+        sections = ['ISSUE TYPE', 'COMPONENT NAME', 'ANSIBLE VERSION', 'SUMMARY']
+        tdata = extract_template_data(
+            body, issue_number=issue_number,
+            issue_class=issue_class, sections=sections
+        )
+        assert tdata.get('ansible version') == '1.9.x'
+        assert tdata.get('issue type') == 'bug report'
+        assert tdata.get('component name') == 'widget'
+        assert tdata.get('component_raw') == 'widget, thingamajig'
+        assert tdata.get('summary') == 'the widget AND thingamig modules are broken!!!'


### PR DESCRIPTION
Create function for scrubbing bad characters with a few exceptions based on regular expressions.
Add additional test for when Markdown headers have the option `####` at the end of the line.