### PR TITLE
set owner_pr when only when submitter is maintainer of all modified files, handle module_utils

### DIFF
--- a/ansibullbot/triagers/plugins/shipit.py
+++ b/ansibullbot/triagers/plugins/shipit.py
@@ -215,6 +215,18 @@ def get_shipit_facts(issuewrapper, meta, module_indexer, core_team=[], botnames=
 
     if not iw.is_pullrequest():
         return nmeta
+
+    module_utils_files_owned = 0  # module_utils files for which submitter is maintainer
+    if meta['is_module_util']:
+        for f in iw.files:
+            if f.startswith('lib/ansible/module_utils') and f in module_indexer.botmeta['files']:
+                maintainers = module_indexer.botmeta['files'][f].get('maintainers', [])
+                if maintainers and (iw.submitter in maintainers):
+                    module_utils_files_owned += 1
+        if module_utils_files_owned == len(iw.files):
+            nmeta['owner_pr'] = True
+            return nmeta
+
     if not meta['module_match']:
         return nmeta
 

--- a/ansibullbot/triagers/plugins/shipit.py
+++ b/ansibullbot/triagers/plugins/shipit.py
@@ -247,8 +247,12 @@ def get_shipit_facts(issuewrapper, meta, module_indexer, core_team=[], botnames=
             bots=botnames
         )
 
-    if not meta['is_new_module'] and iw.submitter in maintainers:
-        nmeta['owner_pr'] = True
+    modules_files_owned = 0
+    if not meta['is_new_module']:
+        for f in iw.files:
+            if f.startswith('lib/ansible/modules') and iw.submitter in module_indexer.modules[f]['maintainers']:
+                modules_files_owned += 1
+    nmeta['owner_pr'] = modules_files_owned + module_utils_files_owned == len(iw.files)
 
     # community is the other maintainers in the same namespace
     mnamespace = meta['module_match']['namespace']

--- a/ansibullbot/utils/moduletools.py
+++ b/ansibullbot/utils/moduletools.py
@@ -225,55 +225,7 @@ class ModuleIndexer(object):
 
         matches = sorted(set(matches))
 
-        # figure out the names
-        for match in matches:
-            mdict = copy.deepcopy(self.EMPTY_MODULE)
-
-            mdict['filename'] = os.path.basename(match)
-
-            dirpath = os.path.dirname(match)
-            dirpath = dirpath.replace(self.checkoutdir + '/', '')
-            mdict['dirpath'] = dirpath
-
-            filepath = match.replace(self.checkoutdir + '/', '')
-            mdict['filepath'] = filepath
-
-            mdict.update(
-                self.split_topics_from_path(filepath)
-            )
-
-            mdict['repo_filename'] = mdict['filepath']\
-                .replace('lib/ansible/modules/%s/' % mdict['repository'], '')
-
-            # clustering/consul
-            mdict['namespaced_module'] = mdict['repo_filename']
-            mdict['namespaced_module'] = \
-                mdict['namespaced_module'].replace('.py', '')
-            mdict['namespaced_module'] = \
-                mdict['namespaced_module'].replace('.ps1', '')
-
-            mname = os.path.basename(match)
-            mname = mname.replace('.py', '')
-            mname = mname.replace('.ps1', '')
-            mdict['name'] = mname
-
-            # deprecated modules
-            if mname.startswith('_'):
-                mdict['deprecated'] = True
-                deprecated_filename = \
-                    os.path.dirname(mdict['namespaced_module'])
-                deprecated_filename = \
-                    os.path.join(deprecated_filename, mname[1:] + '.py')
-                mdict['deprecated_filename'] = deprecated_filename
-            else:
-                mdict['deprecated_filename'] = mdict['repo_filename']
-
-            self.modules[filepath] = mdict
-
-        # meta is a special module
-        self.modules['meta'] = copy.deepcopy(self.EMPTY_MODULE)
-        self.modules['meta']['name'] = 'meta'
-        self.modules['meta']['repo_filename'] = 'meta'
+        self.populate_modules(matches)
 
         # custom fixes
         newitems = []
@@ -327,6 +279,57 @@ class ModuleIndexer(object):
         self.set_maintainers()
 
         return self.modules
+
+    def populate_modules(self, matches):
+        # figure out the names
+        for match in matches:
+            mdict = copy.deepcopy(self.EMPTY_MODULE)
+
+            mdict['filename'] = os.path.basename(match)
+
+            dirpath = os.path.dirname(match)
+            dirpath = dirpath.replace(self.checkoutdir + '/', '')
+            mdict['dirpath'] = dirpath
+
+            filepath = match.replace(self.checkoutdir + '/', '')
+            mdict['filepath'] = filepath
+
+            mdict.update(
+                self.split_topics_from_path(filepath)
+            )
+
+            mdict['repo_filename'] = mdict['filepath']\
+                .replace('lib/ansible/modules/%s/' % mdict['repository'], '')
+
+            # clustering/consul
+            mdict['namespaced_module'] = mdict['repo_filename']
+            mdict['namespaced_module'] = \
+                mdict['namespaced_module'].replace('.py', '')
+            mdict['namespaced_module'] = \
+                mdict['namespaced_module'].replace('.ps1', '')
+
+            mname = os.path.basename(match)
+            mname = mname.replace('.py', '')
+            mname = mname.replace('.ps1', '')
+            mdict['name'] = mname
+
+            # deprecated modules
+            if mname.startswith('_'):
+                mdict['deprecated'] = True
+                deprecated_filename = \
+                    os.path.dirname(mdict['namespaced_module'])
+                deprecated_filename = \
+                    os.path.join(deprecated_filename, mname[1:] + '.py')
+                mdict['deprecated_filename'] = deprecated_filename
+            else:
+                mdict['deprecated_filename'] = mdict['repo_filename']
+
+            self.modules[filepath] = mdict
+
+        # meta is a special module
+        self.modules['meta'] = copy.deepcopy(self.EMPTY_MODULE)
+        self.modules['meta']['name'] = 'meta'
+        self.modules['meta']['repo_filename'] = 'meta'
 
     def get_module_commits(self):
         keys = self.modules.keys()

--- a/tests/unit/triagers/plugins/test_shipit.py
+++ b/tests/unit/triagers/plugins/test_shipit.py
@@ -1,18 +1,24 @@
 #!/usr/bin/env python
 
-from copy import deepcopy
+import copy
 import json
 import logging
+import os
 import shutil
 import tempfile
+import textwrap
 import unittest
 
+import six
+six.add_move(six.MovedModule('mock', 'mock', 'unittest.mock'))
+from six.moves import mock
+
 from tests.utils.issue_mock import IssueMock
-from tests.utils.repo_mock import RepoMock
 from tests.utils.helpers import get_issue
+from tests.utils.module_indexer_mock import create_indexer
+from ansibullbot.triagers.plugins.component_matching import get_component_match_facts
 from ansibullbot.triagers.plugins.shipit import get_shipit_facts
 from ansibullbot.wrappers.issuewrapper import IssueWrapper
-from ansibullbot.wrappers.historywrapper import HistoryWrapper
 
 
 class ModuleIndexerMock(object):
@@ -22,6 +28,22 @@ class ModuleIndexerMock(object):
 
     def get_maintainers_for_namespace(self, namespace):
         return self.namespace_maintainers
+
+
+class FileIndexerMock(object):
+    def find_component_matches_by_file(self, filenames):
+        return []
+
+    def isnewdir(self, path):
+        return False
+
+    def get_component_labels(self, files, valid_labels=None):
+        return []
+
+
+class MockFile(object):
+    def __init__(self, name):
+        self.filename = name
 
 
 class TestShipitFacts(unittest.TestCase):
@@ -35,6 +57,7 @@ class TestShipitFacts(unittest.TestCase):
             },
             'is_needs_revision': False,  # always set by needs_revision plugin (get_needs_revision_facts)
             'is_needs_rebase': False,
+            'is_module_util': False,
         }
 
     def test_submitter_is_maintainer(self):
@@ -96,7 +119,7 @@ class TestShipitFacts(unittest.TestCase):
         """
         needs_rebase label prevents shipit label to be added
         """
-        meta = deepcopy(self.meta)
+        meta = copy.deepcopy(self.meta)
         meta['is_needs_rebase'] = True
         self.needs_rebase_or_revision_prevent_shipit(meta)
 
@@ -104,6 +127,233 @@ class TestShipitFacts(unittest.TestCase):
         """
         needs_revision label prevents shipit label to be added
         """
-        meta = deepcopy(self.meta)
+        meta = copy.deepcopy(self.meta)
         meta['is_needs_revision'] = True
         self.needs_rebase_or_revision_prevent_shipit(meta)
+
+
+class TestOwnerPR(unittest.TestCase):
+
+    def setUp(self):
+        self.meta = {
+            'is_needs_revision': False,  # always set by needs_revision plugin (get_needs_revision_facts)
+            'is_needs_rebase': False,
+        }
+
+    def test_owner_pr_submitter_is_maintainer_one_module_utils_file_updated(self):
+        """
+        Submitter is a maintainer: ensure owner_pr is set (only one file below module_utils updated)
+        """
+        BOTMETA = """
+        ---
+        macros:
+            modules: lib/ansible/modules
+            module_utils: lib/ansible/module_utils
+        files:
+            $module_utils/foo/bar.py:
+                maintainers: ElsA Oliver
+        """
+
+        modules = {'lib/ansible/module_utils/foo/bar.py': None}
+        module_indexer = create_indexer(textwrap.dedent(BOTMETA), modules)
+
+        self.assertEqual(len(module_indexer.modules), 2)  # ensure only fake data are loaded
+        self.assertEqual(sorted(module_indexer.botmeta['files']['lib/ansible/module_utils/foo/bar.py']['maintainers']), ['ElsA', 'Oliver'])
+
+        issue = IssueMock('/dev/null')
+        issue.user.login = 'ElsA'
+        issue.html_url = 'https://github.com/ansible/ansible/pull/123'
+        iw = IssueWrapper(cachedir="", issue=issue)
+        iw.pr_files = [MockFile('lib/ansible/module_utils/foo/bar.py')]
+
+        meta = self.meta.copy()
+        meta.update(get_component_match_facts(iw, None, FileIndexerMock(), module_indexer, []))
+        facts = get_shipit_facts(iw, meta, module_indexer, core_team=['bcoca', 'mscherer'], botnames=['ansibot'])
+
+        self.assertEqual(iw.submitter, 'ElsA')
+        self.assertTrue(facts['owner_pr'])
+
+    def test_owner_pr_submitter_is_maintainer_one_modules_file_updated(self):
+        """
+        Submitter is a maintainer: ensure owner_pr is set (only one file below modules updated)
+        """
+        BOTMETA = """
+        ---
+        macros:
+            modules: lib/ansible/modules
+            module_utils: lib/ansible/module_utils
+        files:
+            $modules/foo/bar.py:
+                maintainers: ElsA mscherer
+        """
+
+        modules = {'lib/ansible/modules/foo/bar.py': None}
+        module_indexer = create_indexer(textwrap.dedent(BOTMETA), modules)
+
+        self.assertEqual(len(module_indexer.modules), 2)  # ensure only fake data are loaded
+        self.assertEqual(sorted(module_indexer.botmeta['files']['lib/ansible/modules/foo/bar.py']['maintainers']), ['ElsA', 'mscherer'])
+
+        meta = self.meta.copy()
+
+        datafile = 'tests/fixtures/shipit/0_issue.yml'
+        statusfile = 'tests/fixtures/shipit/0_prstatus.json'
+        with get_issue(datafile, statusfile) as iw:
+            iw.pr_files = [MockFile('lib/ansible/modules/foo/bar.py')]
+
+            meta.update(get_component_match_facts(iw, {}, FileIndexerMock(), module_indexer, []))
+            facts = get_shipit_facts(iw, meta, module_indexer, core_team=['bcoca'], botnames=['ansibot'])
+
+        self.assertEqual(iw.submitter, 'mscherer')
+        self.assertTrue(facts['owner_pr'])
+
+    def test_owner_pr_submitter_is_maintainer_new_module(self):
+        """
+        Submitter is a maintainer: pull request adds a new module: ensure owner_pr is False
+        """
+        BOTMETA = """
+        ---
+        macros:
+            modules: lib/ansible/modules
+            module_utils: lib/ansible/module_utils
+        files:
+            $modules/foo/bar.py:
+                maintainers: ElsA mscherer
+        """
+
+        modules = {}  # new module
+        module_indexer = create_indexer(textwrap.dedent(BOTMETA), modules)
+
+        self.assertEqual(len(module_indexer.modules), 1)  # ensure only fake data are loaded
+        # Ensure that BOTMETA.yml updates doesn't interfere
+        self.assertEqual(sorted(module_indexer.botmeta['files']['lib/ansible/modules/foo/bar.py']['maintainers']), ['ElsA', 'mscherer'])
+
+        meta = self.meta.copy()
+
+        datafile = 'tests/fixtures/shipit/0_issue.yml'
+        statusfile = 'tests/fixtures/shipit/0_prstatus.json'
+        with get_issue(datafile, statusfile) as iw:
+            iw.pr_files = [MockFile('lib/ansible/modules/foo/bar.py')]
+
+            meta.update(get_component_match_facts(iw, {}, FileIndexerMock(), module_indexer, []))
+            facts = get_shipit_facts(iw, meta, module_indexer, core_team=['bcoca'], botnames=['ansibot'])
+
+        self.assertEqual(iw.submitter, 'mscherer')
+        self.assertFalse(facts['owner_pr'])
+
+    def test_owner_pr_submitter_is_not_maintainer_of_all_updated_files(self):
+        """
+        PR updates 2 files below module_utils, submitter is a maintainer from only one: ensure owner_pr isn't set
+        """
+        BOTMETA = """
+        ---
+        macros:
+            modules: lib/ansible/modules
+            module_utils: lib/ansible/module_utils
+        files:
+            $module_utils/foo/bar.py:
+                maintainers: ElsA Oliver
+            $module_utils/baz/bar.py:
+                maintainers: TiTi ZaZa
+        """
+
+        module_indexer = create_indexer(textwrap.dedent(BOTMETA), {})
+
+        self.assertEqual(len(module_indexer.modules), 1)  # ensure only fake data are loaded
+        self.assertEqual(sorted(module_indexer.botmeta['files']['lib/ansible/module_utils/foo/bar.py']['maintainers']), ['ElsA', 'Oliver'])
+        self.assertEqual(sorted(module_indexer.botmeta['files']['lib/ansible/module_utils/baz/bar.py']['maintainers']), ['TiTi', 'ZaZa'])
+
+        issue = IssueMock('/dev/null')
+        issue.user.login = 'ElsA'
+        issue.html_url = 'https://github.com/ansible/ansible/pull/123'
+        iw = IssueWrapper(cachedir="", issue=issue)
+        iw.pr_files = [
+            MockFile('lib/ansible/module_utils/foo/bar.py'),
+            MockFile('lib/ansible/module_utils/baz/bar.py')
+        ]
+
+        meta = self.meta.copy()
+        meta.update(get_component_match_facts(iw, {}, FileIndexerMock(), module_indexer, []))
+        facts = get_shipit_facts(iw, meta, module_indexer, core_team=['bcoca', 'mscherer'], botnames=['ansibot'])
+
+        self.assertEqual(iw.submitter, 'ElsA')
+        self.assertFalse(facts['owner_pr'])
+
+    def test_owner_pr_module_utils_and_modules_updated_submitter_maintainer_1(self):
+        """
+        PR updates 2 files (one below modules, the other below module_utils),
+        submitter is a maintainer from both, check that owner_pr is set.
+        Submitter is maintainer from module file.
+        """
+        BOTMETA = """
+        ---
+        macros:
+            modules: lib/ansible/modules
+            module_utils: lib/ansible/module_utils
+        files:
+            $modules/foo/bar.py:
+                maintainers: ElsA mscherer
+            $module_utils/baz/bar.py:
+                maintainers: TiTi ZaZa
+        """
+
+        modules = {'lib/ansible/modules/foo/bar.py': None}
+        module_indexer = create_indexer(textwrap.dedent(BOTMETA), modules)
+
+        self.assertEqual(len(module_indexer.modules), 2)  # ensure only fake data are loaded
+        self.assertEqual(sorted(module_indexer.botmeta['files']['lib/ansible/modules/foo/bar.py']['maintainers']), ['ElsA', 'mscherer'])
+        self.assertEqual(sorted(module_indexer.botmeta['files']['lib/ansible/module_utils/baz/bar.py']['maintainers']), ['TiTi', 'ZaZa'])
+
+        meta = self.meta.copy()
+
+        datafile = 'tests/fixtures/shipit/0_issue.yml'
+        statusfile = 'tests/fixtures/shipit/0_prstatus.json'
+        with get_issue(datafile, statusfile) as iw:
+            iw.pr_files = [
+                MockFile('lib/ansible/modules/foo/bar.py'),
+                MockFile('lib/ansible/module_utils/baz/bar.py')
+            ]
+            meta.update(get_component_match_facts(iw, {}, FileIndexerMock(), module_indexer, []))
+            facts = get_shipit_facts(iw, meta, module_indexer, core_team=['bcoca', 'mscherer'], botnames=['ansibot'])
+
+        self.assertEqual(iw.submitter, 'mscherer')
+        self.assertFalse(facts['owner_pr'])
+
+    def test_owner_pr_module_utils_and_modules_updated_submitter_maintainer_2(self):
+        """
+        PR updates 2 files (one below modules, the other below module_utils),
+        submitter is a maintainer from both, check that owner_pr is set.
+        Submitter is maintainer from module_utils file.
+        """
+        BOTMETA = """
+        ---
+        macros:
+            modules: lib/ansible/modules
+            module_utils: lib/ansible/module_utils
+        files:
+            $modules/foo/bar.py:
+                maintainers: ElsA ZaZa
+            $module_utils/baz/bar.py:
+                maintainers: TiTi mscherer
+        """
+
+        modules = {'lib/ansible/modules/foo/bar.py': None}
+        module_indexer = create_indexer(textwrap.dedent(BOTMETA), modules)
+
+        self.assertEqual(len(module_indexer.modules), 2)  # ensure only fake data are loaded
+        self.assertEqual(sorted(module_indexer.botmeta['files']['lib/ansible/modules/foo/bar.py']['maintainers']), ['ElsA', 'ZaZa'])
+        self.assertEqual(sorted(module_indexer.botmeta['files']['lib/ansible/module_utils/baz/bar.py']['maintainers']), ['TiTi', 'mscherer'])
+
+        meta = self.meta.copy()
+
+        datafile = 'tests/fixtures/shipit/0_issue.yml'
+        statusfile = 'tests/fixtures/shipit/0_prstatus.json'
+        with get_issue(datafile, statusfile) as iw:
+            iw.pr_files = [
+                MockFile('lib/ansible/modules/foo/bar.py'),
+                MockFile('lib/ansible/module_utils/baz/bar.py')
+            ]
+            meta.update(get_component_match_facts(iw, {}, FileIndexerMock(), module_indexer, []))
+            facts = get_shipit_facts(iw, meta, module_indexer, core_team=['bcoca'], botnames=['ansibot'])
+
+        self.assertEqual(iw.submitter, 'mscherer')
+        self.assertFalse(facts['owner_pr'])

--- a/tests/utils/module_indexer_mock.py
+++ b/tests/utils/module_indexer_mock.py
@@ -1,0 +1,44 @@
+import six
+from ansibullbot.utils.moduletools import ModuleIndexer
+
+six.add_move(six.MovedModule('mock', 'mock', 'unittest.mock'))
+from six.moves import mock
+
+
+def create_indexer(BOTMETA, filepaths):
+    """Create and test ModuleIndexer
+
+    1. parse BOTMETA metadata
+    2. list source code paths (filepaths keys)
+    3. fetch authors from source code content (filepaths values)
+
+    filepaths = {
+        'lib/ansible/modules/foo/bar/baz.py': None, # no author in source code
+        'lib/ansible/modules/foo2/bar2/baz.py': ['author1', 'author2'],
+    }
+    """
+    def set_modules(self):
+        '''list modules from filesystem'''
+        self.populate_modules(filepaths.keys())
+
+    def set_authors(self, mfile):
+        '''set authors from module source code: 'author' field in DOCUMENTATION metadata'''
+        for (filepath, authors) in filepaths.items():
+            if mfile.endswith(filepath):
+                if not authors:
+                    return []
+                else:
+                    return authors
+        assert False
+
+    @mock.patch.object(ModuleIndexer, 'update')
+    @mock.patch.object(ModuleIndexer, 'get_module_authors', side_effect=set_authors, autospec=True)
+    @mock.patch.object(ModuleIndexer, 'get_ansible_modules', side_effect=set_modules, autospec=True)
+    @mock.patch.object(ModuleIndexer, 'get_file_content', return_value=BOTMETA)
+    def indexer(m_update, m_authors, m_modules, m_content):
+        module_indexer = ModuleIndexer()
+        module_indexer.parse_metadata()
+        module_indexer.set_maintainers()
+        return module_indexer
+
+    return indexer()


### PR DESCRIPTION
This pull request allows to:
- set `owner_pr` label when pull request updates file below `lib/ansible/module_utils` and submitter is maintainer of these file
- set `owner_pr` only when submitter if maintainer of each updated files (see https://github.com/ansible/ansibullbot/issues/776#issuecomment-334428396)
- `owner_pr` won't be set if an updated file isn't below `lib/ansible/module_utils` or `lib/ansible/modules` is modified

Unit tests provided.

Closes #776 