### PR TITLE
needs_rebase and needs_revision prevent shipit label to be added

### DIFF
--- a/ansibullbot/triagers/plugins/shipit.py
+++ b/ansibullbot/triagers/plugins/shipit.py
@@ -223,6 +223,10 @@ def get_shipit_facts(issuewrapper, meta, module_indexer, core_team=[], botnames=
         logging.debug('WIP PRs do not get shipits')
         return nmeta
 
+    if meta['is_needs_revision'] or meta['is_needs_rebase']:
+        logging.debug('PRs with needs_revision or needs_rebase label do not get shipits')
+        return nmeta
+
     maintainers = meta['module_match']['maintainers']
     maintainers = \
         ModuleIndexer.replace_ansible(


### PR DESCRIPTION
This pull request prevents `shipit` label to be added when `needs_rebase` or `needs_revision` label is already set.

Unit tests provided.

Closes #783 