### PR TITLE
Handle GraphQL errors on a status 200

### DIFF
--- a/ansibullbot/utils/gh_gql_client.py
+++ b/ansibullbot/utils/gh_gql_client.py
@@ -336,6 +336,13 @@ class GithubGraphQLClient(object):
     def requests(self, payload):
         response = requests.post(self.baseurl, headers=self.headers, data=json.dumps(payload))
         response.raise_for_status()
+        # GitHub GraphQL will happily return a 200 result with errors. One
+        # must dig through the data to see if there were errors.
+	errors = response.json().get('errors')
+        if errors:
+            msgs = ', '.join([e['message'] for e in errors])
+            raise requests.exceptions.InvalidSchema(
+                'Error(s) from graphql: %s' % msgs)
         return response
 
 ###################################


### PR DESCRIPTION
GitHub's GraphQL can return 200s with errors, if say the schema
submitted to it was invalid. This can break anything trying to make use
of the json data and expecting real values and structure. This bit of
code will detect when errors come back and will do a raise.