### PR TITLE
Don't notify anyone when branch contains a merge commit

### DIFF
--- a/ansibullbot/triagers/plugins/notifications.py
+++ b/ansibullbot/triagers/plugins/notifications.py
@@ -12,6 +12,9 @@ def get_notification_facts(issuewrapper, meta, file_indexer):
         'to_assign': []
     }
 
+    if iw.is_pullrequest() and iw.merge_commits:
+        return nfacts
+
     # who is assigned?
     current_assignees = iw.assignees
 


### PR DESCRIPTION
Another fix could be to test `self.meta.get('merge_commits')` in [`create_actions`](https://github.com/pilou-/ansibullbot/blob/dont_notify_if_there_is_a_merge_commit/ansibullbot/triagers/ansible.py#L1050) but this method is already long enough.

Tested manually using both a pull-request and an issue:
```
./triage_ansible.py --dry-run --logfile /tmp/bot.log --pr 32576 # no notification
./triage_ansible.py --dry-run --logfile /tmp/bot.log --pr 30599 # no exception
```

Fixes #787