### PR TITLE
Deprecated modules: fix handling of maintainers

### DIFF
--- a/ansibullbot/triagers/plugins/notifications.py
+++ b/ansibullbot/triagers/plugins/notifications.py
@@ -12,6 +12,9 @@ def get_notification_facts(issuewrapper, meta, file_indexer):
         'to_assign': []
     }
 
+    if iw.is_pullrequest() and iw.merge_commits:
+        return nfacts
+
     # who is assigned?
     current_assignees = iw.assignees
 

--- a/ansibullbot/utils/moduletools.py
+++ b/ansibullbot/utils/moduletools.py
@@ -372,36 +372,7 @@ class ModuleIndexer(object):
 
         self.populate_modules(matches)
 
-        # custom fixes
-        newitems = []
-        for k,v in self.modules.iteritems():
-
-            # include* is almost always an ansible/ansible issue
-            # https://github.com/ansible/ansibullbot/issues/214
-            if k.endswith('/include.py'):
-                self.modules[k]['repository'] = 'ansible'
-            # https://github.com/ansible/ansibullbot/issues/214
-            if k.endswith('/include_vars.py'):
-                self.modules[k]['repository'] = 'ansible'
-            if k.endswith('/include_role.py'):
-                self.modules[k]['repository'] = 'ansible'
-
-            # ansible maintains these
-            if 'include' in k:
-                self.modules[k]['maintainers'] = ['ansible']
-
-            # deprecated modules are annoying
-            if v['name'].startswith('_'):
-
-                dkey = os.path.dirname(v['filepath'])
-                dkey = os.path.join(dkey, v['filename'].replace('_', '', 1))
-                if dkey not in self.modules:
-                    nd = v.copy()
-                    nd['name'] = nd['name'].replace('_', '', 1)
-                    newitems.append((dkey, nd))
-
-        for ni in newitems:
-            self.modules[ni[0]] = ni[1]
+        self.modules_reorg()
 
         # parse metadata
         logging.debug('set module metadata')
@@ -477,6 +448,39 @@ class ModuleIndexer(object):
         self.modules['meta'] = copy.deepcopy(self.EMPTY_MODULE)
         self.modules['meta']['name'] = 'meta'
         self.modules['meta']['repo_filename'] = 'meta'
+
+    def modules_reorg(self):
+        """Apply some fixes on self.modules"""
+        # custom fixes
+        newitems = []
+        for k, v in self.modules.iteritems():
+
+            # include* is almost always an ansible/ansible issue
+            # https://github.com/ansible/ansibullbot/issues/214
+            if k.endswith('/include.py'):
+                self.modules[k]['repository'] = 'ansible'
+            # https://github.com/ansible/ansibullbot/issues/214
+            if k.endswith('/include_vars.py'):
+                self.modules[k]['repository'] = 'ansible'
+            if k.endswith('/include_role.py'):
+                self.modules[k]['repository'] = 'ansible'
+
+            # ansible maintains these
+            if 'include' in k:
+                self.modules[k]['maintainers'] = ['ansible']
+
+            # deprecated modules are annoying
+            if v['name'].startswith('_'):
+
+                dkey = os.path.dirname(v['filepath'])
+                dkey = os.path.join(dkey, v['filename'].replace('_', '', 1))
+                if dkey not in self.modules:
+                    nd = v.copy()
+                    nd['name'] = nd['name'].replace('_', '', 1)
+                    newitems.append((dkey, nd))
+
+        for ni in newitems:
+            self.modules[ni[0]] = ni[1]
 
     def get_module_commits(self):
         keys = self.modules.keys()

--- a/ansibullbot/utils/moduletools.py
+++ b/ansibullbot/utils/moduletools.py
@@ -769,24 +769,33 @@ class ModuleIndexer(object):
                 sorted(set(self.modules[k]['maintainers']))
 
         metadata = self.botmeta['files'].keys()
-        for k,v in self.modules.iteritems():
+        for k, v in self.modules.iteritems():
             if k == 'meta':
                 continue
 
-            if k in self.botmeta['files']:
+            # BOTMETA might refer to lib/ansible/modules/namespace/module.py
+            # even if module has been deprecated, meaning the path of the module
+            # is in fact lib/ansible/modules/namespace/_module.py
+            deprecated = self.modules[k]['deprecated_filename']
+            if deprecated:
+                mfile = deprecated
+            else:
+                mfile = k
+
+            if mfile in self.botmeta['files']:
                 # There are metadata in .github/BOTMETA.yml for this file
                 # copy maintainers_keys
-                self.modules[k]['maintainers_keys'] = self.botmeta['files'][k]['maintainers_keys'][:]
+                self.modules[k]['maintainers_keys'] = self.botmeta['files'][mfile]['maintainers_keys'][:]
 
-                if self.botmeta['files'][k]:
-                    maintainers = self.botmeta['files'][k].get('maintainers', [])
+                if self.botmeta['files'][mfile]:
+                    maintainers = self.botmeta['files'][mfile].get('maintainers', [])
                     for maintainer in maintainers:
                         if maintainer not in self.modules[k]['maintainers']:
                             self.modules[k]['maintainers'].append(maintainer)
 
                     # remove the people who want to be ignored
-                    if 'ignored' in self.botmeta['files'][k]:
-                        ignored = self.botmeta['files'][k]['ignored']
+                    if 'ignored' in self.botmeta['files'][mfile]:
+                        ignored = self.botmeta['files'][mfile]['ignored']
                         for x in ignored:
                             if x in self.modules[k]['maintainers']:
                                 self.modules[k]['maintainers'].remove(x)

--- a/tests/unit/utils/test_module_indexer.py
+++ b/tests/unit/utils/test_module_indexer.py
@@ -177,6 +177,7 @@ class TestModuleIndexer(TestCase):
 
         indexer = create_indexer(textwrap.dedent(self.BOTMETA), filepaths)
 
+        # -1: ignore 'meta' entry
         self.assertEqual(len(indexer.modules) - 1, len(filepaths))  # ensure only fake data are loaded
 
         for k in expected:
@@ -207,6 +208,7 @@ class TestModuleIndexer(TestCase):
 
         indexer = create_indexer(textwrap.dedent(self.BOTMETA), filepaths)
 
+        # -1: ignore 'meta' entry
         self.assertEqual(len(indexer.modules) - 1, len(filepaths))  # ensure only fake data are loaded
         self.assertEqual(sorted(indexer.modules['lib/ansible/modules/baz/test/code.py']['maintainers']), expected_maintainers)
 
@@ -230,6 +232,7 @@ class TestModuleIndexer(TestCase):
 
         indexer = create_indexer(textwrap.dedent(BOTMETA), filepaths)
 
+        # -1: ignore 'meta' entry
         self.assertEqual(len(indexer.modules) - 1, len(filepaths))  # ensure only fake data are loaded
         self.assertEqual(sorted(indexer.modules['lib/ansible/modules/baz/test/code.py']['maintainers']), expected_maintainers)
 
@@ -259,6 +262,7 @@ class TestModuleIndexer(TestCase):
 
         indexer = create_indexer(textwrap.dedent(BOTMETA), filepaths)
 
+        # -1: ignore 'meta' entry
         self.assertEqual(len(indexer.modules) - 1, len(filepaths))  # ensure only fake data are loaded
         self.assertEqual(sorted(indexer.modules['lib/ansible/modules/baz/test/code1.py']['maintainers']), ['ElsA'])
         self.assertEqual(sorted(indexer.modules['lib/ansible/modules/baz/test/code2.py']['maintainers']), sorted(['ElsA', 'Oliver']))
@@ -293,5 +297,6 @@ class TestModuleIndexer(TestCase):
 
         indexer = create_indexer(textwrap.dedent(BOTMETA), filepaths)
 
+        # -1: ignore 'meta' entry
         self.assertEqual(len(indexer.modules) - 1, len(filepaths))  # ensure only fake data are loaded
         self.assertEqual(sorted(indexer.modules['lib/ansible/modules/baz/test/code.py']['maintainers']), expected_maintainers)

--- a/tests/utils/module_indexer_mock.py
+++ b/tests/utils/module_indexer_mock.py
@@ -20,6 +20,7 @@ def create_indexer(BOTMETA, filepaths):
     def set_modules(self):
         '''list modules from filesystem'''
         self.populate_modules(filepaths.keys())
+        self.modules_reorg()
 
     def set_authors(self, mfile):
         '''set authors from module source code: 'author' field in DOCUMENTATION metadata'''


### PR DESCRIPTION
`̀BOTMETA.yml` entries applying to deprecated modules were ignored.

For example [`modules/cloud/azure/azure.py`](https://github.com/ansible/ansible/blob/35acae7ea7b62aec3d33c6b96630f750e5b2b43b/.github/BOTMETA.yml#L156) entry was ignored because the module has been deprecated and has been renamed to [`modules/cloud/azure/_azure.py`](https://github.com/ansible/ansible/tree/35acae7ea7b62aec3d33c6b96630f750e5b2b43b/lib/ansible/modules/cloud/azure).

This pull-request allows to take in account entries related to deprecated modules.

Not sure if there is any advantage to handle deprecated modules like [that](https://github.com/ansible/ansibullbot/blob/76cd2da9ab0d50221c1d69795661db28fe9c9f8e/ansibullbot/utils/moduletools.py#L393): I mean instead of having two entries in `self.modules` for each deprecated module, only the one corresponding to the deprecated path could be kept (then `BOTMETA.yml` should be updated when a module become deprecated).

Unit tests provided.