### PR TITLE
Figure out original issue submitter

### DIFF
--- a/ansibullbot/wrappers/defaultwrapper.py
+++ b/ansibullbot/wrappers/defaultwrapper.py
@@ -23,6 +23,7 @@ import logging
 import operator
 import os
 import pickle
+import re
 import shutil
 import sys
 import time
@@ -848,6 +849,13 @@ class DefaultWrapper(object):
 
     @property
     def submitter(self):
+        # auto-migrated issue by ansibot{-dev}
+        # figure out the original submitter
+        if self.instance.user.login.startswith('ansibot'):
+            m = re.match('From @(.*) on', self.instance.body)
+            if m:
+                return m.group(1)
+
         return self.instance.user.login
 
     @property


### PR DESCRIPTION
This is a partial fix for https://github.com/ansible/ansibullbot/issues/856. The remaining part is to go through the issues that ping ansibot for response, ping the original submitter instead and set needs info back.