### PR TITLE
Fixes a few recent tracebacks

### DIFF
--- a/ansibullbot/triagers/plugins/needs_revision.py
+++ b/ansibullbot/triagers/plugins/needs_revision.py
@@ -107,11 +107,12 @@ def get_needs_revision_facts(triager, issuewrapper, meta, shippable=None):
     ci_status = iw.pullrequest_status
 
     # code quality hooks
-    if [x for x in ci_status if 'landscape.io' in x['target_url']]:
+    if [x for x in ci_status if isinstance(x, dict) and
+            'landscape.io' in x['target_url']]:
         has_landscape = True
 
     ci_states = [x['state'] for x in ci_status
-                 if 'shippable.com' in x['target_url']]
+                 if isinstance(x, dict) and 'shippable.com' in x['target_url']]
 
     if not ci_states:
         ci_state = None

--- a/ansibullbot/utils/webscraper.py
+++ b/ansibullbot/utils/webscraper.py
@@ -951,8 +951,9 @@ class GithubWebScraper(object):
         if not data['updated_at']:
             events = comments + commits
             events = sorted(set(events))
-            data['updated_at'] = events[-1]
-            #import epdb; epdb.st()
+            if events:
+                data['updated_at'] = events[-1]
+            else:
+                data['updated_at'] = data['created_at']
 
-        #import epdb; epdb.st()
         return data


### PR DESCRIPTION
fixes https://github.com/ansible/ansibullbot/issues/861

also fixes ...

```
2018-02-13 12:05:02,385 INFO ansible version: 2.6.0devel
2018-02-13 12:05:02,386 INFO Starting new HTTPS connection (1): api.github.com
2018-02-13 12:05:02,489 DEBUG "GET /rate_limit HTTP/1.1" 200 None
2018-02-13 12:05:02,493 DEBUG ratelimited call #1 [<class 'ansibullbot.wrappers.issuewrapper.IssueWrapper'>] [load_update_fetch] [2112]
2018-02-13 12:05:02,496 INFO Starting new HTTPS connection (1): api.github.com
2018-02-13 12:05:02,612 DEBUG "GET /rate_limit HTTP/1.1" 200 None
2018-02-13 12:05:02,617 DEBUG ratelimited call #1 [<class 'ansibullbot.wrappers.issuewrapper.IssueWrapper'>] [pullrequest_raw_data] [2112]
2018-02-13 12:05:02,617 INFO pullrequest_status load pfile
2018-02-13 12:05:02,617 ERROR Uncaught exception
Traceback (most recent call last):
  File "/home/ansibot/ansibullbot/triage_ansible.py", line 42, in <module>
    main()
  File "/home/ansibot/ansibullbot/triage_ansible.py", line 38, in main
    AnsibleTriage().start()
  File "/home/ansibot/ansibullbot/ansibullbot/triagers/defaulttriager.py", line 179, in start
    self.loop()
  File "/home/ansibot/ansibullbot/ansibullbot/triagers/defaulttriager.py", line 289, in loop
    self.run()
  File "/home/ansibot/ansibullbot/ansibullbot/triagers/ansible.py", line 436, in run
    self.process(iw)
  File "/home/ansibot/ansibullbot/ansibullbot/triagers/ansible.py", line 1745, in process
    self.meta,
  File "/home/ansibot/ansibullbot/ansibullbot/triagers/plugins/needs_revision.py", line 110, in get_needs_revision_facts
    if [x for x in ci_status if 'landscape.io' in x['target_url']]:
TypeError: string indices must be integers
```