### PR TITLE
Make bot add performance label

### DIFF
--- a/ansibullbot/triagers/ansible.py
+++ b/ansibullbot/triagers/ansible.py
@@ -72,6 +72,7 @@ from ansibullbot.triagers.plugins.needs_revision import get_needs_revision_facts
 from ansibullbot.triagers.plugins.needs_revision import get_shippable_run_facts
 from ansibullbot.triagers.plugins.contributors import get_contributor_facts
 from ansibullbot.triagers.plugins.notifications import get_notification_facts
+from ansibullbot.triagers.plugins.performance import get_performance_facts
 from ansibullbot.triagers.plugins.py3 import get_python3_facts
 from ansibullbot.triagers.plugins.shipit import automergeable
 from ansibullbot.triagers.plugins.shipit import get_review_facts
@@ -1113,6 +1114,11 @@ class AnsibleTriage(DefaultTriager):
             if comment not in actions.comments:
                 actions.comments.append(comment)
 
+        # performance issue/PR
+        if self.meta['is_performance']:
+            if 'performance' not in iw.labels:
+                actions.newlabel.append('performance')
+
         # label commands
         if self.meta['label_cmds']:
             if self.meta['label_cmds']['add']:
@@ -1736,6 +1742,9 @@ class AnsibleTriage(DefaultTriager):
 
         # backports
         self.meta.update(get_backport_facts(iw, self.meta))
+
+        # performance
+        self.meta.update(get_performance_facts(iw, self.meta))
 
         # shipit?
         self.meta.update(

--- a/ansibullbot/triagers/plugins/performance.py
+++ b/ansibullbot/triagers/plugins/performance.py
@@ -1,0 +1,19 @@
+#!/usr/bin/env python
+
+def get_performance_facts(issuewrapper, meta):
+    iw = issuewrapper
+
+    pfacts = {
+        'is_performance': False
+    }
+
+    body = iw.body.lower()
+    title = iw.title.lower()
+
+    # TODO search in comments too?
+    for data in (body, title):
+        if 'performance' in data:
+            pfacts['is_performance'] = True
+            break
+
+    return pfacts


### PR DESCRIPTION
Allows for easier tracking of performance issues/PRs.

Tested on:
https://github.com/ansible/ansible/issues/36431 (`performance` in `body`)
https://github.com/ansible/ansible/issues/32678 (`performance` in `title`)
https://github.com/ansible/ansible/pull/36626 (no `performance`)