### PR TITLE
`documentation report` & `docs pull request` should add label:docs

### DIFF
--- a/ansibullbot/triagers/ansible.py
+++ b/ansibullbot/triagers/ansible.py
@@ -121,8 +121,8 @@ class AnsibleTriage(DefaultTriager):
         'bugfix pull request': 'bugfix_pull_request',
         'feature idea': 'feature_idea',
         'feature pull request': 'feature_pull_request',
-        'documentation report': 'docs_report',
-        'docs pull request': 'docs_pull_request',
+        'documentation report': 'docs',
+        'docs pull request': 'docs',
         'new module pull request': 'new_plugin'
     }
 


### PR DESCRIPTION
Just use a single label `docs` not `docs_pull_request` or `docs_request`
See https://github.com/ansible/ansible/pull/36757