### PR TITLE
Remove is_needs_info debug

### DIFF
--- a/ansibullbot/triagers/plugins/needs_info.py
+++ b/ansibullbot/triagers/plugins/needs_info.py
@@ -136,8 +136,6 @@ def needs_info_timeout_facts(iw, meta):
         'needs_info_action': None
     }
 
-    meta['is_needs_info'] = True
-
     if not meta['is_needs_info']:
         return nif
 


### PR DESCRIPTION
I think this https://github.com/ansible/ansibullbot/pull/888/files#diff-c047accbde02f1182f15063bdcc95291R139 caused all newly created issues got `needs_info`, e.g.:
https://github.com/ansible/ansible/pull/37594