### PR TITLE
Update multiple module template

### DIFF
--- a/templates/multiple_module_notify.j2
+++ b/templates/multiple_module_notify.j2
@@ -1,6 +1,6 @@
-@{{ submitter }} this PR contains more than one new module. 
+@{{ submitter }} this PR contains more than one new module.
 
-Please submit only one new module per pullrequest. For further explanation, please read [grouped module documentation](http://docs.ansible.com/ansible/dev_guide/developing_modules_in_groups.html)
+Please submit only one new module per pull request. For a detailed explanation, please read [the grouped modules documentation](https://docs.ansible.com/ansible/latest/dev_guide/developing_modules_in_groups.html)
 
 [click here for bot help](https://github.com/ansible/ansibullbot/blob/master/ISSUE_HELP.md)
 <!--- boilerplate: multiple_module_notify --->


### PR DESCRIPTION
The current link takes people to https://docs.ansible.com/ansible/latest/dev_guide/index.html instead of to the correct documentation page, making it somewhat difficult to track down the actual documentation that it's supposed to be referencing.