### PR TITLE
Link to devel docs

### DIFF
--- a/ISSUE_HELP.md
+++ b/ISSUE_HELP.md
@@ -93,7 +93,7 @@ Once the pull request labeled with [`shipit`](#label-shipit), the module will be
 
 #### Existing Modules
 
-Module's have metadata with a [`supported_by`](http://docs.ansible.com/ansible/latest/dev_guide/developing_modules_documenting.html#ansible-metadata-block) field per the [metadata proposal](https://github.com/ansible/proposals/issues/30).
+Module's have metadata with a [`supported_by`](http://docs.ansible.com/ansible/devel/dev_guide/developing_modules_documenting.html#ansible-metadata-block) field per the [metadata proposal](https://github.com/ansible/proposals/issues/30).
 
 :information_source: If you have **changes to other files in the pull request**, the `supported_by` property is ignored because the Ansible core team **must** approve those changes. When other changes are line deletions in `ansible/test/*/*.txt` files, the `supported_by` property isn't ignored.
 
@@ -187,10 +187,10 @@ Label | Scope | Prevent automerge | Description
 **<a name="label-needs_ci">needs_ci</a>** | pull requests | no | Identify pull requests for which CI status is missing. When a pull request is closed and reopened or when new commits are updated, the CI is triggered again.
 **<a name="label-needs_info">needs_info</a>** | issues | yes | Identify issues for which reviewer requested further information.
 **<a name="label-waiting_on_contributor">waiting_on_contributor</a>** | issues pull requests | no | Identify issues for which help is needed
-**<a name="label-needs_maintainer">needs_maintainer</a>** | pull requests | no | Ansibullbot is unable to identify authors or maintainers of the related module. Check `author` field format in [`DOCUMENTATION block`](http://docs.ansible.com/ansible/dev_guide/developing_modules_documenting.html#documentation-block).
+**<a name="label-needs_maintainer">needs_maintainer</a>** | pull requests | no | Ansibullbot is unable to identify authors or maintainers of the related module. Check `author` field format in [`DOCUMENTATION block`](http://docs.ansible.com/ansible/devel/dev_guide/developing_modules_documenting.html#documentation-block).
 **<a name="label-merge_commit">merge_commit</a>** | pull requests | no | Added to pull requests containing at least one merge commit. Pull requests must not contain merge commit.
 **<a name="label-needs_revision">needs_revision</a>** | pull requests | yes | Used for pull request which fail continuous integration tests or if a maintainer has requested a review/revision of the code. This label can be cleared by fixing any failed tests or by commenting [`ready_for_review`](#cmd-ready_for_review).
-**<a name="label-needs_rebase">needs_rebase</a>** | pull requests | yes | Pull requests which are out of sync with ansible/ansible's `devel` branch. Please review the [rebase guide](http://docs.ansible.com/ansible/dev_guide/developing_rebasing.html) for further information.
+**<a name="label-needs_rebase">needs_rebase</a>** | pull requests | yes | Pull requests which are out of sync with ansible/ansible's `devel` branch. Please review the [rebase guide](http://docs.ansible.com/ansible/devel/dev_guide/developing_rebasing.html) for further information.
 **<a name="label-needs_template">needs_template</a>** | issues pull requests | no | Label added when description is incomplete. See [issue template](https://raw.githubusercontent.com/ansible/ansible/devel/.github/ISSUE_TEMPLATE.md), pull request [template](https://raw.githubusercontent.com/ansible/ansible/devel/.github/PULL_REQUEST_TEMPLATE.md).
 **<a name="label-needs_triage">needs_triage</a>** | issues pull requests | no | This label will be added if your issue is being labeled for the first time. We (ansible staff and maintainers) use this label to find issues that need a human first touch. We'll remove it once we've given the issue a quick look for any labeling problems or missing data.
 **<a name="label-filament">filament</a>** | pull requests | no | Identify pull requests related to [Ansible Lightbulb](https://github.com/ansible/lightbulb) project.

--- a/templates/community_review_existing.j2
+++ b/templates/community_review_existing.j2
@@ -1,3 +1,3 @@
-Thanks @{{ submitter }}. To the current maintainers, @{{ maintainer|join(', @') }} please review according to guidelines (http://docs.ansible.com/ansible/developing_modules.html#module-checklist) and comment with text 'shipit', 'needs_revision' or 'close_me' as appropriate.
+Thanks @{{ submitter }}. To the current maintainers, @{{ maintainer|join(', @') }} please review according to guidelines (http://docs.ansible.com/ansible/devel/dev_guide/developing_modules_checklist.html) and comment with text 'shipit', 'needs_revision' or 'close_me' as appropriate.
 
 [This message brought to you by your friendly Ansibull-bot.]

--- a/templates/core_review_existing.j2
+++ b/templates/core_review_existing.j2
@@ -1,5 +1,5 @@
 Thanks @{{ submitter }} for this PR. This module is maintained by the Ansible core team, so it can take a while for patches to be reviewed. Thanks for your patience.
 
-Core team: please review according to guidelines (http://docs.ansible.com/ansible/developing_modules.html#module-checklist) and comment with 'needs_revision' or merge as appropriate.
+Core team: please review according to guidelines (http://docs.ansible.com/ansible/devel/dev_guide/developing_modules_checklist.html) and comment with 'needs_revision' or merge as appropriate.
 
 [This message brought to you by your friendly Ansibull-bot.]

--- a/templates/issue_invalid_module.j2
+++ b/templates/issue_invalid_module.j2
@@ -1,7 +1,7 @@
 @{{ submitter }} we are unable to validate that "{{ component_name }}" is an existing ansible module.
 
 We are expecting a component name that matches something that can be found in:
-* http://docs.ansible.com/ansible/list_of_all_modules.html
+* http://docs.ansible.com/ansible/devel/modules/list_of_all_modules.html
 
 Please revise the component name in the description.
 [click here for bot help](https://github.com/ansible/ansibullbot/blob/master/ISSUE_HELP.md)

--- a/templates/merge_commit_notify.j2
+++ b/templates/merge_commit_notify.j2
@@ -4,7 +4,7 @@
 * {{ commit }}
 {% endfor %}
 
-Please [rebase your branch](http://docs.ansible.com/ansible/dev_guide/developing_rebasing.html) to remove these commits.
+Please [rebase your branch](http://docs.ansible.com/ansible/devel/dev_guide/index.html) to remove these commits.
 
 [click here for bot help](https://github.com/ansible/ansibullbot/blob/master/ISSUE_HELP.md)
 <!--- boilerplate: merge_commit_notify --->

--- a/templates/multiple_module_notify.j2
+++ b/templates/multiple_module_notify.j2
@@ -1,6 +1,6 @@
 @{{ submitter }} this PR contains more than one new module.
 
-Please submit only one new module per pull request. For a detailed explanation, please read [the grouped modules documentation](https://docs.ansible.com/ansible/latest/dev_guide/developing_modules_in_groups.html)
+Please submit only one new module per pull request. For a detailed explanation, please read [the grouped modules documentation](https://docs.ansible.com/ansible/devel/dev_guide/developing_modules_in_groups.html)
 
 [click here for bot help](https://github.com/ansible/ansibullbot/blob/master/ISSUE_HELP.md)
 <!--- boilerplate: multiple_module_notify --->

--- a/templates/needs_revision_not_mergeable.j2
+++ b/templates/needs_revision_not_mergeable.j2
@@ -1,5 +1,5 @@
 Thanks @{{ submitter }} for this PR. Unfortunately, it is not mergeable in its current state due to merge conflicts. Please rebase your PR. When you are done, please comment with text 'ready_for_review' and we will put this PR back into review.
 
-For help on how to do this cleanly please see http://docs.ansible.com/ansible/community.html#contributing-code-features-or-bugfixes
+For help on how to do this cleanly please see http://docs.ansible.com/ansible/devel/dev_guide/developing_rebasing.html
 
 [This message brought to you by your friendly Ansibull-bot.]

--- a/templates/new_issue_alert.j2
+++ b/templates/new_issue_alert.j2
@@ -11,7 +11,7 @@ The oldest unreviewed module in the queue (please give it some love this week):
 {{oldest_module_string}}
 
 Full list of modules is here:
-https://github.com/ansible/ansible-modules-extras/labels/new_plugin
+https://github.com/ansible/ansible/labels/new_plugin
 
 If you think one of these modules might be useful to you, please download it and test it.
 
@@ -20,8 +20,5 @@ If you've tested a module and found issues, please respond with "needs_revision"
 If you've tested a module and it works for you, please help us by commenting with "shipit" in the pull request.  (Please do not give a "shipit" without actually testing the module first!)
 
 Two "shipit" comments and no "needs_revision" comments will move it to final review for inclusion in the next release.
-
-For help on how to test Ansible pull requests:
-http://docs.ansible.com/ansible/developing_test_pr.html
 
 Thanks for your help in testing Ansible modules!

--- a/templates/no_shippable_yaml.j2
+++ b/templates/no_shippable_yaml.j2
@@ -1,4 +1,4 @@
-@{{ submitter }} Your branch does not contain a shippable.yml file. Please [rebase your branch](http://docs.ansible.com/ansible/dev_guide/developing_rebasing.html) to trigger running of current tests.
+@{{ submitter }} Your branch does not contain a shippable.yml file. Please [rebase your branch](http://docs.ansible.com/ansible/devel/dev_guide/developing_rebasing.html) to trigger running of current tests.
 
 [click here for bot help](https://github.com/ansible/ansibullbot/blob/master/ISSUE_HELP.md)
 <!--- boilerplate: no_shippable_yaml --->

--- a/templates/repomerge.j2
+++ b/templates/repomerge.j2
@@ -1,5 +1,5 @@
 This repository has been locked. All new issues and pull requests should be filed in https://github.com/ansible/ansible
 
-Please read through the <a href="http://docs.ansible.com/ansible/dev_guide/repomerge.html#move-issues-and-prs-to-new-repo">repomerge</a> page in the dev guide. The guide contains links to tools which automatically move your issue or pull request to the ansible/ansible repo.
+Please read through the <a href="http://docs.ansible.com/ansible/devel/dev_guide/repomerge.html">repomerge</a> page in the dev guide. The guide contains links to tools which automatically move your issue or pull request to the ansible/ansible repo.
 
 <!-- boilerplate: repomerge -->

--- a/templates/repomerge_new.j2
+++ b/templates/repomerge_new.j2
@@ -1,5 +1,5 @@
 This repository has been locked. All new issues and pull requests should be filed in https://github.com/ansible/ansible
 
-Please read through the <a href="http://docs.ansible.com/ansible/dev_guide/repomerge.html#move-issues-and-prs-to-new-repo">repomerge</a> page in the dev guide.
+Please read through the <a href="http://docs.ansible.com/ansible/devel/dev_guide/repomerge.html">repomerge</a> page in the dev guide.
 
 <!--- boilerplate: repomerge_new --->

--- a/templates/travis_notify.j2
+++ b/templates/travis_notify.j2
@@ -1,4 +1,4 @@
-@{{ submitter }} this PR was tested by travis-ci.org, which is no longer used. Please [rebase your branch](http://docs.ansible.com/ansible/dev_guide/developing_rebasing.html) to trigger running of current tests.
+@{{ submitter }} this PR was tested by travis-ci.org, which is no longer used. Please [rebase your branch](http://docs.ansible.com/ansible/devel/dev_guide/developing_rebasing.html) to trigger running of current tests.
 
 [click here for bot help](https://github.com/ansible/ansibullbot/blob/master/ISSUE_HELP.md)
 <!--- boilerplate: travis_notify --->


### PR DESCRIPTION
As PRs go into the devel branch, contributors should be following the
devel guides, rather than the "latest" stable release.

Ensure ensure that we link to direct pages, rather than requiring
redirects.