### PR TITLE
[RFC] Add small_patch label

### DIFF
--- a/ansibullbot/triagers/ansible.py
+++ b/ansibullbot/triagers/ansible.py
@@ -82,6 +82,7 @@ from ansibullbot.triagers.plugins.shipit import get_review_facts
 from ansibullbot.triagers.plugins.shipit import get_shipit_facts
 from ansibullbot.triagers.plugins.shipit import get_submitter_facts
 from ansibullbot.triagers.plugins.shipit import needs_community_review
+from ansibullbot.triagers.plugins.small_patch import get_small_patch_facts
 from ansibullbot.triagers.plugins.traceback import get_traceback_facts
 
 from ansibullbot.parsers.botmetadata import BotMetadataParser
@@ -1200,6 +1201,16 @@ class AnsibleTriage(DefaultTriager):
                     if label in actions.newlabel:
                         actions.newlabel.remove(label)
 
+        # small patch?
+        if iw.is_pullrequest():
+            label_name = 'small_patch'
+            if self.meta['is_small_patch']:
+                if label_name not in iw.labels:
+                    actions.newlabel.append(label_name)
+            else:
+                if label_name in iw.labels:
+                    actions.unlabel.append(label_name)
+
         if iw.is_pullrequest():
 
             # https://github.com/ansible/ansibullbot/issues/312
@@ -1819,6 +1830,9 @@ class AnsibleTriage(DefaultTriager):
 
         # traceback
         self.meta.update(get_traceback_facts(iw))
+
+        # small_patch
+        self.meta.update(get_small_patch_facts(iw))
 
         # shipit?
         self.meta.update(

--- a/ansibullbot/triagers/plugins/small_patch.py
+++ b/ansibullbot/triagers/plugins/small_patch.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python
+
+import re
+
+
+FILE_MAX_CHANGED_LINES = 6
+SMALL_CHUNKS_MAX_COUNT = 2
+
+RE_CHUNK = r'@@ -\d+,\d+ \+\d+,\d+ @@'
+
+
+def get_small_patch_facts(iw):
+    sfacts = {
+        'is_small_patch': False
+    }
+
+    small_chunks_changed = 0
+
+    for commit in iw.get_commits():
+        for changed_file in commit.files:
+            if changed_file.filename.startswith('test/'):
+                continue
+
+            if not changed_file.raw_data['status'] == 'modified':
+                return sfacts
+
+            chunks_in_file_count = len(re.findall(RE_CHUNK, changed_file.raw_data['patch']))
+
+            if changed_file.changes > FILE_MAX_CHANGED_LINES:
+                return sfacts
+            elif changed_file.changes:
+                small_chunks_changed += chunks_in_file_count
+
+        if small_chunks_changed > SMALL_CHUNKS_MAX_COUNT:
+            return sfacts
+
+
+    if small_chunks_changed:
+        sfacts['is_small_patch'] = True
+
+    return sfacts


### PR DESCRIPTION
Fixes https://github.com/ansible/ansibullbot/issues/393

Will add tests once we agree on the starter heuristic.

@abadger proposed the following in the issue:
> * no more than two hunks of code are changed.
> * Each hunk should be at most three lines changed.

I could not figure out how to count changes in each chunk in a sane way so the code does the following:
* any new or deleted files in a PR are not classified as `small_patch`
* each modified file in a PR can change 6 lines at most (additions and deletions)
* tests are not counted as a change, see PR I tested on below (but PRs only containing tests are not `small_patch`)
* PR can have two chunks of changed code at most

So if I have not confused myself, the biggest `small_patch` could be two changed files with 6 added lines in each. Thinking about it, 6 sounds more that it should be though.

Tested on:
* https://github.com/ansible/ansible/pull/40338
* https://github.com/ansible/ansible/pull/36870

Thoughts?