### PR TITLE
Don't get CI facts on issues

### DIFF
--- a/ansibullbot/triagers/plugins/ci_rebuild.py
+++ b/ansibullbot/triagers/plugins/ci_rebuild.py
@@ -34,6 +34,9 @@ def status_to_date_and_runid(status, keepstate=False):
 
 
 def get_ci_facts(iw):
+    if not iw.is_pullrequest():
+        return {'ci_run_number': None}
+
     pr_status = [x for x in iw.pullrequest_status]
     ci_run_ids = [status_to_date_and_runid(x) for x in pr_status]
     ci_run_ids.sort(key=lambda x: x[0])


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/home/ansibot/ansibullbot/triage_ansible.py", line 42, in <module>
    main()
  File "/home/ansibot/ansibullbot/triage_ansible.py", line 38, in main
    AnsibleTriage().start()
  File "/home/ansibot/ansibullbot/ansibullbot/triagers/defaulttriager.py", line 180, in start
    self.loop()
  File "/home/ansibot/ansibullbot/ansibullbot/triagers/defaulttriager.py", line 290, in loop
    self.run()
  File "/home/ansibot/ansibullbot/ansibullbot/triagers/ansible.py", line 443, in run
    self.process(iw)
  File "/home/ansibot/ansibullbot/ansibullbot/triagers/ansible.py", line 1908, in process
    self.meta.update(get_ci_facts(iw))
  File "/home/ansibot/ansibullbot/ansibullbot/triagers/plugins/ci_rebuild.py", line 37, in get_ci_facts
    pr_status = [x for x in iw.pullrequest_status]
  File "/home/ansibot/ansibullbot/ansibullbot/wrappers/defaultwrapper.py", line 1010, in pullrequest_status
    self._pr_status = self.get_pullrequest_status(force_fetch=False)
  File "/home/ansibot/ansibullbot/ansibullbot/wrappers/defaultwrapper.py", line 927, in get_pullrequest_status
    rd = self.pullrequest_raw_data
  File "/home/ansibot/ansibullbot/ansibullbot/decorators/github.py", line 131, in inner
    raise Exception('unhandled message type')
Exception: unhandled message type
```