### PR TITLE
Fix IndexError in getting ci_facts

### DIFF
--- a/ansibullbot/triagers/plugins/ci_rebuild.py
+++ b/ansibullbot/triagers/plugins/ci_rebuild.py
@@ -34,13 +34,20 @@ def status_to_date_and_runid(status, keepstate=False):
 
 
 def get_ci_facts(iw):
+    cifacts = {
+        'ci_run_number': None
+    }
+
     if not iw.is_pullrequest():
-        return {'ci_run_number': None}
+        return cifacts
 
     pr_status = [x for x in iw.pullrequest_status]
     ci_run_ids = [status_to_date_and_runid(x) for x in pr_status]
     ci_run_ids.sort(key=lambda x: x[0])
-    last_run = ci_run_ids[-1][1]
+    if ci_run_ids:
+        last_run = ci_run_ids[-1][1]
+    else:
+        return cifacts
 
     return {'ci_run_number': last_run}
 


### PR DESCRIPTION
```
2018-05-23 15:15:18,997 DEBUG WIP PRs do not get shipits
2018-05-23 15:15:19,002 ERROR Uncaught exception
Traceback (most recent call last):
File "/home/ansibot/ansibullbot/triage_ansible.py", line 42, in
main()
File "/home/ansibot/ansibullbot/triage_ansible.py", line 38, in main
AnsibleTriage().start()
File "/home/ansibot/ansibullbot/ansibullbot/triagers/defaulttriager.py", line 180, in start
self.loop()
File "/home/ansibot/ansibullbot/ansibullbot/triagers/defaulttriager.py", line 290, in loop
self.run()
File "/home/ansibot/ansibullbot/ansibullbot/triagers/ansible.py", line 443, in run
self.process(iw)
File "/home/ansibot/ansibullbot/ansibullbot/triagers/ansible.py", line 1908, in process
self.meta.update(get_ci_facts(iw))
File "/home/ansibot/ansibullbot/ansibullbot/triagers/plugins/ci_rebuild.py", line 43, in get_ci_facts
last_run = ci_run_ids[-1][1]
IndexError: list index out of range
```