### PR TITLE
Fix json error on NamedUser

### DIFF
--- a/ansibullbot/wrappers/historywrapper.py
+++ b/ansibullbot/wrappers/historywrapper.py
@@ -668,7 +668,7 @@ class HistoryWrapper(object):
             if hasattr(xc.committer, 'login'):
                 event['actor'] = xc.committer.login
             else:
-                event['actor'] = xc.committer
+                event['actor'] = str(xc.committer)
             #event['created_at'] = dts
             event['created_at'] = adts
             event['event'] = 'committed'


### PR DESCRIPTION
https://github.com/ansible/ansible/pull/40785

```
Traceback (most recent call last):
  File "/home/ansibot/ansibullbot/triage_ansible.py", line 42, in <module>
    main()
  File "/home/ansibot/ansibullbot/triage_ansible.py", line 38, in main
    AnsibleTriage().start()
  File "/home/ansibot/ansibullbot/ansibullbot/triagers/defaulttriager.py", line 180, in start
    self.loop()
  File "/home/ansibot/ansibullbot/ansibullbot/triagers/defaulttriager.py", line 290, in loop
    self.run()
  File "/home/ansibot/ansibullbot/ansibullbot/triagers/ansible.py", line 453, in run
    self.save_meta(iw, self.meta, actions)
  File "/home/ansibot/ansibullbot/ansibullbot/triagers/ansible.py", line 635, in save_meta
    self.dump_meta(issuewrapper, dmeta)
  File "/home/ansibot/ansibullbot/ansibullbot/triagers/ansible.py", line 723, in dump_meta
    json.dump(meta, f, sort_keys=True, indent=2)
  File "/usr/lib64/python2.7/json/__init__.py", line 189, in dump
    for chunk in iterable:
  File "/usr/lib64/python2.7/json/encoder.py", line 434, in _iterencode
    for chunk in _iterencode_dict(o, _current_indent_level):
  File "/usr/lib64/python2.7/json/encoder.py", line 408, in _iterencode_dict
    for chunk in chunks:
  File "/usr/lib64/python2.7/json/encoder.py", line 332, in _iterencode_list
    for chunk in chunks:
  File "/usr/lib64/python2.7/json/encoder.py", line 408, in _iterencode_dict
    for chunk in chunks:
  File "/usr/lib64/python2.7/json/encoder.py", line 442, in _iterencode
    o = _default(o)
  File "/usr/lib64/python2.7/json/encoder.py", line 184, in default
    raise TypeError(repr(o) + " is not JSON serializable")
TypeError: NamedUser(login=None) is not JSON serializable
```