### PR TITLE
Don't fail when diff is temporarily unavailable

### DIFF
--- a/ansibullbot/triagers/plugins/small_patch.py
+++ b/ansibullbot/triagers/plugins/small_patch.py
@@ -20,6 +20,10 @@ def get_small_patch_facts(iw):
     small_chunks_changed = 0
 
     for commit in iw.get_commits():
+        if commit.files is None:
+            # "Sorry, this diff is temporarily unavailable due to heavy server load."
+            return sfacts
+
         for changed_file in commit.files:
             if changed_file.filename.startswith('test/'):
                 continue


### PR DESCRIPTION
Fix failing `small_patch` when "Sorry, this diff is temporarily unavailable due to heavy server load.".