### PR TITLE
Fix 'NoneType' object has no attribute 'group'

### DIFF
--- a/ansibullbot/triagers/plugins/component_matching.py
+++ b/ansibullbot/triagers/plugins/component_matching.py
@@ -164,8 +164,9 @@ def get_component_match_facts(issuewrapper, meta, component_matcher, file_indexe
                 for line in lbpc.split('\n'):
                     if line.startswith('*'):
                         parts = line.split()
-                        fn = re.match('\[(\S+)\].*', parts[1]).group(1)
-                        _filenames.append(fn)
+                        m = re.match('\[(\S+)\].*', parts[1])
+                        if m:
+                            _filenames.append(m.group(1))
                 _filenames = sorted(set(_filenames))
                 expected = sorted(set([x['repo_filename'] for x in CM_MATCHES]))
                 if _filenames != expected:


### PR DESCRIPTION
```
2018-07-24 15:58:28,088 INFO starting triage for https://github.com/ansible/ansible/issues/42977
Traceback (most recent call last):
  File "/home/ansibot/ansibullbot/triage_ansible.py", line 42, in 
    main()
  File "/home/ansibot/ansibullbot/triage_ansible.py", line 38, in main
    AnsibleTriage().start()
  File "/home/ansibot/ansibullbot/ansibullbot/triagers/defaulttriager.py", line 180, in start
    self.loop()
  File "/home/ansibot/ansibullbot/ansibullbot/triagers/defaulttriager.py", line 290, in loop
    self.run()
  File "/home/ansibot/ansibullbot/ansibullbot/triagers/ansible.py", line 445, in run
    self.process(iw)
  File "/home/ansibot/ansibullbot/ansibullbot/triagers/ansible.py", line 1827, in process
    self.valid_labels
  File "/home/ansibot/ansibullbot/ansibullbot/triagers/plugins/component_matching.py", line 167, in get_component_match_facts
    fn = re.match('\[(\S+)\].*', parts[1]).group(1)
AttributeError: 'NoneType' object has no attribute 'group'
```