### PR TITLE
Update ansibullbot role

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -53,7 +53,7 @@ gathering = smart
 host_key_checking = False
 
 # change the default callback
-#stdout_callback = skippy
+stdout_callback = debug
 # enable additional callbacks
 #callback_whitelist = profile_tasks
 


### PR DESCRIPTION
Looks like this role was a bit behind. Mainly adding tasks to `monitoring.yml` that allow the `apache` user to read the ansibullbot code checkout so it can display it in the status page.