### PR TITLE
Fix NoneType exception in RateLimited

### DIFF
--- a/ansibullbot/decorators/github.py
+++ b/ansibullbot/decorators/github.py
@@ -131,7 +131,7 @@ def RateLimited(fn):
                         raise Exception('unhandled message type')
             except Exception as e:
                 logging.error(e)
-                if hasattr(e, 'data') and e.data.get('message'):
+                if hasattr(e, 'data') and e.data is not None and e.data.get('message'):
                     msg = e.data.get('message')
                     if 'blocked from content creation' in msg:
                         logging.warning('content creation rate limit exceeded')


### PR DESCRIPTION
```
2018-08-06 05:07:40,173 INFO starting triage for https://github.com/ansible/ansible/pull/43671
Traceback (most recent call last):
  File "/home/ansibot/ansibullbot/triage_ansible.py", line 42, in 
    main()
  File "/home/ansibot/ansibullbot/triage_ansible.py", line 38, in main
    AnsibleTriage().start()
  File "/home/ansibot/ansibullbot/ansibullbot/triagers/defaulttriager.py", line 180, in start
    self.loop()
  File "/home/ansibot/ansibullbot/ansibullbot/triagers/defaulttriager.py", line 290, in loop
    self.run()
  File "/home/ansibot/ansibullbot/ansibullbot/triagers/ansible.py", line 438, in run
    iw.update_pullrequest()
  File "/home/ansibot/ansibullbot/ansibullbot/wrappers/defaultwrapper.py", line 880, in update_pullrequest
    self._pr = self.repo.get_pullrequest(self.number)
  File "/home/ansibot/ansibullbot/ansibullbot/decorators/github.py", line 134, in inner
    if hasattr(e, 'data') and e.data.get('message'):
AttributeError: 'NoneType' object has no attribute 'get'
```