### PR TITLE
fix compat with POSIX shell

### DIFF
--- a/ansibullbot/utils/component_tools.py
+++ b/ansibullbot/utils/component_tools.py
@@ -159,9 +159,9 @@ class AnsibleComponentMatcher(object):
         # make a list of names by calling ansible-doc
         checkoutdir = self.gitrepo.checkoutdir
         checkoutdir = os.path.abspath(checkoutdir)
-        cmd = 'source {}/hacking/env-setup; ansible-doc -t module -F'.format(checkoutdir)
+        cmd = '. {}/hacking/env-setup; ansible-doc -t module -F'.format(checkoutdir)
         logging.debug(cmd)
-        (rc, so, se) = run_command(cmd)
+        (rc, so, se) = run_command(cmd, cwd=checkoutdir)
         lines = so.split('\n')
         for line in lines:
 

--- a/ansibullbot/utils/systemtools.py
+++ b/ansibullbot/utils/systemtools.py
@@ -3,8 +3,8 @@
 import subprocess
 
 
-def run_command(cmd):
-    p = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+def run_command(cmd, cwd=None):
+    p = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, cwd=cwd)
     (so, se) = p.communicate()
     return p.returncode, so, se
 


### PR DESCRIPTION
Fix compatibility with shell with POSIX features only (eg `dash`):
* use `.` instead of `source`
  Fix this error:

      /bin/sh: 1: source: not found

* and set `cwd` (otherwise [`HACKING_DIR`](https://github.com/ansible/ansible/blob/ac895828c1a57e8054eb80969d214fad399d252e/hacking/env-setup#L42) default to `PWD` when POSIX shell is used and then `ANSIBLE_HOME` is wrong)