### PR TITLE
Install Ansible dependencies too

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,5 @@ sqlalchemy
 tenacity
 textblob
 mock ; python_version < '3.3'
+
+-r https://raw.githubusercontent.com/ansible/ansible/devel/requirements.txt

--- a/shippable.yml
+++ b/shippable.yml
@@ -6,6 +6,7 @@ build:
    - mkdir -p shippable/testresults
    - mkdir -p shippable/codecoverage
 
+   - shippable_retry pip install --upgrade 'pip>=9.0'
    - shippable_retry pip install -r requirements.txt
    - shippable_retry pip install nose coverage
    - nosetests --with-xunit --xunit-file=shippable/testresults/nosetests.xml --with-coverage --cover-package=ansibullbot --cover-xml --cover-xml-file=shippable/codecoverage/coverage.xml


### PR DESCRIPTION
`ansible-doc` is used by `AnsibleComponentMatcher`:
https://github.com/ansible/ansibullbot/blob/149f8e099a8d5822805418c62c73f3fd6256371f/ansibullbot/utils/component_tools.py#L162
then Ansible dependencies must be installed too.

It should fix shippable errors reported by shippable build of #999:
```
ERROR: test_reduce_filepaths (tests.unit.utils.test_component_tools.TestComponentMatcher)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/root/src/github.com/ansible/ansibullbot/tests/unit/utils/test_component_tools.py", line 116, in test_reduce_filepaths
    CM = get_component_matcher()
  File "/root/src/github.com/ansible/ansibullbot/tests/unit/utils/test_component_tools.py", line 106, in get_component_matcher
    module_indexer=MI
  File "/root/src/github.com/ansible/ansibullbot/ansibullbot/utils/component_tools.py", line 112, in __init__
    self.update()
  File "/root/src/github.com/ansible/ansibullbot/ansibullbot/utils/component_tools.py", line 118, in update
    self.index_files()
  File "/root/src/github.com/ansible/ansibullbot/ansibullbot/utils/component_tools.py", line 166, in index_files
    raise Exception("'ansible-doc' command failed (%s, %s %s)" % (rc, so, se))
Exception: 'ansible-doc' command failed (250, running egg_info
creating lib/ansible.egg-info
writing requirements to lib/ansible.egg-info/requires.txt
writing lib/ansible.egg-info/PKG-INFO
writing top-level names to lib/ansible.egg-info/top_level.txt
writing dependency_links to lib/ansible.egg-info/dependency_links.txt
writing manifest file 'lib/ansible.egg-info/SOURCES.txt'
reading manifest file 'lib/ansible.egg-info/SOURCES.txt'
reading manifest template 'MANIFEST.in'
writing manifest file 'lib/ansible.egg-info/SOURCES.txt'

Setting up Ansible to run out of checkout...

PATH=/tmp/tmpy_ZnqF/ansible/bin:/tmp/tmpy_ZnqF/ansible/test/runner:/root/venv/2.7/bin:/root/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/root/usr/local/bin
PYTHONPATH=/tmp/tmpy_ZnqF/ansible/lib:
MANPATH=/tmp/tmpy_ZnqF/ansible/docs/man:

Remember, you may wish to specify your host file with -i

Done!

the full traceback was:

Traceback (most recent call last):
  File "/tmp/tmpy_ZnqF/ansible/bin/ansible-doc", line 88, in <module>
    mycli = getattr(__import__("ansible.cli.%s" % sub, fromlist=[myclass]), myclass)
  File "/tmp/tmpy_ZnqF/ansible/lib/ansible/cli/__init__.py", line 38, in <module>
    from ansible.inventory.manager import InventoryManager
  File "/tmp/tmpy_ZnqF/ansible/lib/ansible/inventory/manager.py", line 33, in <module>
    from ansible.plugins.loader import PluginLoader
  File "/tmp/tmpy_ZnqF/ansible/lib/ansible/plugins/loader.py", line 22, in <module>
    from ansible.parsing.plugin_docs import read_docstring
  File "/tmp/tmpy_ZnqF/ansible/lib/ansible/parsing/plugin_docs.py", line 12, in <module>
    from ansible.parsing.yaml.loader import AnsibleLoader
  File "/tmp/tmpy_ZnqF/ansible/lib/ansible/parsing/yaml/loader.py", line 30, in <module>
    from ansible.parsing.yaml.constructor import AnsibleConstructor
  File "/tmp/tmpy_ZnqF/ansible/lib/ansible/parsing/yaml/constructor.py", line 29, in <module>
    from ansible.parsing.vault import VaultLib
  File "/tmp/tmpy_ZnqF/ansible/lib/ansible/parsing/vault/__init__.py", line 44, in <module>
    from cryptography.hazmat.backends import default_backend
  File "/root/venv/2.7/local/lib/python2.7/site-packages/cryptography/hazmat/backends/__init__.py", line 7, in <module>
    import pkg_resources
  File "/root/venv/2.7/local/lib/python2.7/site-packages/pkg_resources/__init__.py", line 90, in <module>
    packaging = pkg_resources._vendor.packaging
AttributeError: 'module' object has no attribute '_vendor'
 no previously-included directories found matching 'ticket_stubs'
no previously-included directories found matching 'hacking'
warning: no files found matching 'SYMLINK_CACHE.json'
ERROR! Unexpected Exception, this is probably a bug: 'module' object has no attribute '_vendor'
)
-------------------- >> begin captured stdout << ---------------------
```