### PR TITLE
allow automerge for non module as well

### DIFF
--- a/ansibullbot/triagers/plugins/shipit.py
+++ b/ansibullbot/triagers/plugins/shipit.py
@@ -98,9 +98,6 @@ def get_automerge_facts(issuewrapper, meta):
         if meta[u'is_new_directory']:
             return create_ameta(False, u'automerge is_new_directory test failed')
 
-        if not meta[u'is_module']:
-            return create_ameta(False, u'automerge is_module test failed')
-
         if not meta[u'module_match']:
             return create_ameta(False, u'automerge module_match test failed')
 


### PR DESCRIPTION
Currently, the GitHub filter [`is:pr label:shipit label:support:community -label:backport  -label:module`](https://github.com/ansible/ansible/pulls?q=is:pr+label:shipit+label:support:community+-label:backport+-label:module) matches 3 open pull-requests and 11 merged pull requests.

Is there any reason to prevent automerge for such pull requests ?

cc @gundalow