### PR TITLE
Better info in 'merge failed' exception

### DIFF
--- a/ansibullbot/wrappers/defaultwrapper.py
+++ b/ansibullbot/wrappers/defaultwrapper.py
@@ -1252,7 +1252,7 @@ class DefaultWrapper(object):
                 logging.error('breakpoint!')
                 import epdb; epdb.st()
             else:
-                raise Exception('merge failed')
+                raise Exception('merge failed - %d - %s' % (resp[0], resp[1]['status']))
         else:
             logging.info('merge successful for %s' % self.number)
 


### PR DESCRIPTION
Some failures are due to `405 Method Not Allowed` `You're not authorized to push to this branch.` like if someone does `rebuild_merge` on a backport PR. So just log this info into exception so we don't have to investigate.