### PR TITLE
Use has_in_assignees instead of fetching them all

### DIFF
--- a/ansibullbot/triagers/plugins/notifications.py
+++ b/ansibullbot/triagers/plugins/notifications.py
@@ -18,9 +18,6 @@ def get_notification_facts(issuewrapper, meta, file_indexer):
     # who is assigned?
     current_assignees = iw.assignees
 
-    # who can be assigned?
-    valid_assignees = [x.login for x in iw.repo.assignees]
-
     # add people from files and from matches
     if iw.is_pullrequest() or meta.get('guessed_components') or meta.get('component_matches') or meta.get('module_match'):
 
@@ -101,7 +98,7 @@ def get_notification_facts(issuewrapper, meta, file_indexer):
                 continue
             if user in nfacts['to_assign']:
                 continue
-            if user not in current_assignees and user in valid_assignees:
+            if user not in current_assignees and iw.repo.repo.has_in_assignees(user):
                 nfacts['to_assign'].append(user)
 
     # prevent duplication


### PR DESCRIPTION
With this I am hoping to get rid of the following traceback that we've been getting a lot:
```
2018-09-06 13:15:43,844 INFO starting triage for https://github.com/ansible/ansible/pull/45287
Traceback (most recent call last):
  File "/home/ansibot/ansibullbot/triage_ansible.py", line 42, in 
    main()
  File "/home/ansibot/ansibullbot/triage_ansible.py", line 38, in main
    AnsibleTriage().start()
  File "/home/ansibot/ansibullbot/ansibullbot/triagers/defaulttriager.py", line 180, in start
    self.loop()
  File "/home/ansibot/ansibullbot/ansibullbot/triagers/defaulttriager.py", line 290, in loop
    self.run()
  File "/home/ansibot/ansibullbot/ansibullbot/triagers/ansible.py", line 446, in run
    self.process(iw)
  File "/home/ansibot/ansibullbot/ansibullbot/triagers/ansible.py", line 1876, in process
    self.meta.update(get_notification_facts(iw, self.meta, self.file_indexer))
  File "/home/ansibot/ansibullbot/ansibullbot/triagers/plugins/notifications.py", line 22, in get_notification_facts
    valid_assignees = [x.login for x in iw.repo.assignees]
  File "/home/ansibot/ansibullbot/ansibullbot/wrappers/ghapiwrapper.py", line 155, in assignees
    self._assignees = self.load_update_fetch('assignees')
  File "/home/ansibot/ansibullbot/ansibullbot/decorators/github.py", line 185, in inner
    raise Exception('no data in exception')
Exception: no data in exception
```