### PR TITLE
sanity tests no longer allows `authors:`

### DIFF
--- a/ansibullbot/utils/extractors.py
+++ b/ansibullbot/utils/extractors.py
@@ -501,10 +501,6 @@ class ModuleExtractor(object):
         if not ydata:
             return []
 
-        # sometimes the field is 'author', sometimes it is 'authors'
-        if u'authors' in ydata:
-            ydata[u'author'] = ydata[u'authors']
-
         # quit if the key was not found
         if u'author' not in ydata:
             return []

--- a/ansibullbot/utils/moduletools.py
+++ b/ansibullbot/utils/moduletools.py
@@ -845,10 +845,6 @@ class ModuleIndexer(object):
         if not ydata:
             return []
 
-        # sometimes the field is 'author', sometimes it is 'authors'
-        if u'authors' in ydata:
-            ydata[u'author'] = ydata[u'authors']
-
         # quit if the key was not found
         if u'author' not in ydata:
             return []


### PR DESCRIPTION
The validate-modules sanity tests no longer allow `authors:` to be defined.
And none of the modules have this specified at this time, so this can go.