### PR TITLE
Fix issue with missing support bit

### DIFF
--- a/ansibullbot/utils/component_tools.py
+++ b/ansibullbot/utils/component_tools.py
@@ -1032,7 +1032,9 @@ class AnsibleComponentMatcher(object):
             if len(mmatch) == 1 and mmatch[0]['filename'] == filename:
                 meta['metadata'].update(mmatch[0]['metadata'])
 
-            meta['support'] = meta['metadata']['supported_by']
+            if meta['metadata']:
+                if meta['metadata']['supported_by']:
+                    meta['support'] = meta['metadata']['supported_by']
 
         for entry in botmeta_entries:
             fdata = self.BOTMETA['files'][entry].copy()


### PR DESCRIPTION
```
2018-10-02 03:47:16,621 INFO starting triage for https://github.com/ansible/ansible/pull/42720
Traceback (most recent call last):
  File "/home/ansibot/ansibullbot/triage_ansible.py", line 42, in 
    main()
  File "/home/ansibot/ansibullbot/triage_ansible.py", line 38, in main
    AnsibleTriage().start()
  File "/home/ansibot/ansibullbot/ansibullbot/triagers/defaulttriager.py", line 181, in start
    self.loop()
  File "/home/ansibot/ansibullbot/ansibullbot/triagers/defaulttriager.py", line 292, in loop
    self.run()
  File "/home/ansibot/ansibullbot/ansibullbot/triagers/ansible.py", line 456, in run
    self.process(iw)
  File "/home/ansibot/ansibullbot/ansibullbot/triagers/ansible.py", line 1858, in process
    self.valid_labels
  File "/home/ansibot/ansibullbot/ansibullbot/triagers/plugins/component_matching.py", line 56, in get_component_match_facts
    CM_MATCHES = component_matcher.match(iw)
  File "/home/ansibot/ansibullbot/ansibullbot/utils/component_tools.py", line 288, in match
    files=iw.files
  File "/home/ansibot/ansibullbot/ansibullbot/utils/component_tools.py", line 344, in match_components
    component_matches.append(self.get_meta_for_file(fn))
  File "/home/ansibot/ansibullbot/ansibullbot/utils/component_tools.py", line 1035, in get_meta_for_file
    meta['support'] = meta['metadata']['supported_by']
KeyError: 'supported_by'
```