### PR TITLE
Fix import syntax

### DIFF
--- a/ansibullbot/utils/shippable_api.py
+++ b/ansibullbot/utils/shippable_api.py
@@ -4,7 +4,7 @@
 # https://api.shippable.com/projects/573f79d02a8192902e20e34b | jq .
 
 import ansibullbot.constants as C
-import ansibullbot._text_compat as to_text
+from ansibullbot._text_compat import to_text
 
 import datetime
 import gzip


### PR DESCRIPTION
```
2018-10-08 16:46:34,439 ERROR Uncaught exception
Traceback (most recent call last):
  File "/home/ansibot/ansibullbot/triage_ansible.py", line 42, in <module>
    main()
  File "/home/ansibot/ansibullbot/triage_ansible.py", line 38, in main
    AnsibleTriage().start()
  File "/home/ansibot/ansibullbot/ansibullbot/triagers/defaulttriager.py", line 184, in start
    self.loop()
  File "/home/ansibot/ansibullbot/ansibullbot/triagers/defaulttriager.py", line 295, in loop
    self.run()
  File "/home/ansibot/ansibullbot/ansibullbot/triagers/ansible.py", line 426, in run
    lsr = self.SR.get_last_completion(iw.number)
  File "/home/ansibot/ansibullbot/ansibullbot/utils/shippable_api.py", line 112, in get_last_completion
    nruns = self.get_pullrequest_runs(number)
  File "/home/ansibot/ansibullbot/ansibullbot/utils/shippable_api.py", line 106, in get_pullrequest_runs
    if x[u'commitUrl'].endswith(u'/' + to_text(number)):
TypeError: 'module' object is not callable
```