### PR TITLE
Disable the www since calculation

### DIFF
--- a/ansibullbot/decorators/github.py
+++ b/ansibullbot/decorators/github.py
@@ -197,7 +197,9 @@ def RateLimited(fn):
                     else:
                         ex_type, ex, tb = sys.exc_info()
                         traceback.print_tb(tb)
-                        raise Exception('no data in exception')
+                        #raise Exception('no data in exception')
+                        #raise Exception('no data in exception {ex}')
+                        raise ex
 
                 logging.warning('sleeping %s minutes' % (stime/60))
                 time.sleep(stime)

--- a/ansibullbot/triagers/ansible.py
+++ b/ansibullbot/triagers/ansible.py
@@ -1740,6 +1740,8 @@ class AnsibleTriage(DefaultTriager):
                     (len(numbers), since)
                 )
 
+                # FIXME - disabled after py3 patches
+                '''
                 for k, v in self.issue_summaries[repo].items():
                     if v[u'created_at'] > self.repos[repo][u'since']:
                         numbers.append(k)
@@ -1749,6 +1751,7 @@ class AnsibleTriage(DefaultTriager):
                     u'%s numbers after [www] since == %s' %
                     (len(numbers), since)
                 )
+                '''
 
         if self.start_at and self.repos[repo][u'loopcount'] == 0:
             numbers = [x for x in numbers if x <= self.start_at]


### PR DESCRIPTION
```
2018-10-08 17:46:05,622 INFO 46634 known numbers
2018-10-08 17:46:06,570 INFO 2 numbers after [api] since == 2018-10-08 17:32:08
2018-10-08 17:46:06,781 INFO 2 numbers after [www] since == 2018-10-08 17:32:08
2018-10-08 17:46:06,789 ERROR No JSON object could be decoded
2018-10-08 17:46:06,791 ERROR Uncaught exception
Traceback (most recent call last):
  File "/home/ansibot/ansibullbot/triage_ansible.py", line 42, in <module>
    main()
  File "/home/ansibot/ansibullbot/triage_ansible.py", line 38, in main
    AnsibleTriage().start()
  File "/home/ansibot/ansibullbot/ansibullbot/triagers/defaulttriager.py", line 184, in start
    self.loop()
  File "/home/ansibot/ansibullbot/ansibullbot/triagers/defaulttriager.py", line 295, in loop
    self.run()
  File "/home/ansibot/ansibullbot/ansibullbot/triagers/ansible.py", line 312, in run
    self.collect_repos()
  File "/home/ansibot/ansibullbot/ansibullbot/triagers/ansible.py", line 1671, in collect_repos
    self._collect_repo(repo)
  File "/home/ansibot/ansibullbot/ansibullbot/decorators/github.py", line 200, in inner
    raise Exception('no data in exception')
Exception: no data in exception
```