### PR TITLE
Don't use 'pull-request' instead of 'issue'

### DIFF
--- a/ansibullbot/triagers/ansible.py
+++ b/ansibullbot/triagers/ansible.py
@@ -1188,6 +1188,7 @@ class AnsibleTriage(DefaultTriager):
                 tvars = {
                     u'notify': self.meta[u'to_notify'],
                     u'submitter': iw.submitter,
+                    u'is_pullrequest': iw.is_pullrequest(),
                 }
                 comment = self.render_boilerplate(tvars, boilerplate=u'notify')
                 if comment not in actions.comments:

--- a/templates/notify.j2
+++ b/templates/notify.j2
@@ -1,4 +1,4 @@
-@{{ submitter }}: thank you for submitting this pull-request !
+@{{ submitter }}: thank you for submitting this {% if is_pullrequest %}pull-request{% else %}issue{% endif %}!
 
 {% if notify|length > 1 %}
 cc @{{ notify|join(' @') }}


### PR DESCRIPTION
Don't use `pull-request` instead of `issue` and remove superfluous space.

Closes #1059.