### PR TITLE
Rework 'thank submitter'

### DIFF
--- a/ansibullbot/triagers/ansible.py
+++ b/ansibullbot/triagers/ansible.py
@@ -811,6 +811,18 @@ class AnsibleTriage(DefaultTriager):
                 if u'needs_triage' not in actions.unlabel:
                     actions.unlabel.append(u'needs_triage')
 
+        # Thank submitter
+        if iw.created_at > datetime.datetime(2018, 10, 11): # before, PR could already have been thanked
+            previous_comment = iw.history.last_date_for_boilerplate(u'thank_submitter')
+            if not previous_comment:
+                tvars = {
+                    u'submitter': iw.submitter,
+                    u'is_pullrequest': iw.is_pullrequest(),
+                }
+                comment = self.render_boilerplate(tvars, boilerplate=u'thank_submitter')
+                if comment not in actions.comments:
+                    actions.comments.insert(0, comment) # thank should be first comment
+
         # owner PRs
         if iw.is_pullrequest():
             if self.meta[u'owner_pr']:
@@ -1187,8 +1199,6 @@ class AnsibleTriage(DefaultTriager):
             if self.meta[u'to_notify']:
                 tvars = {
                     u'notify': self.meta[u'to_notify'],
-                    u'submitter': iw.submitter,
-                    u'is_pullrequest': iw.is_pullrequest(),
                 }
                 comment = self.render_boilerplate(tvars, boilerplate=u'notify')
                 if comment not in actions.comments:

--- a/templates/bad_pr.j2
+++ b/templates/bad_pr.j2
@@ -1,4 +1,4 @@
-Thanks @{{ submitter }}! This PR was evaluated as a potentially problematic PR for the following reasons:
+@{{ submitter }} This PR was evaluated as a potentially problematic PR for the following reasons:
 {% for reason in is_bad_pr_reason %}
 * {{ reason }}
 {% endfor %}

--- a/templates/community_workgroups.j2
+++ b/templates/community_workgroups.j2
@@ -1,6 +1,4 @@
-Hi @{{ submitter }},
-
-Thank you for the {% if is_pullrequest %}pullrequest{% else %}issue{% endif %}, just so you are aware we have a dedicated Working Group for {{ wg['workgroup'] }}.
+@{{ submitter }}, just so you are aware we have a dedicated Working Group for {{ wg['workgroup'] }}.
 You can find other people interested in this in `#ansible-{{ wg['workgroup'] }}` on Freenode IRC
 For more information about communities, meetings and agendas see https://github.com/ansible/community
 

--- a/templates/fork.j2
+++ b/templates/fork.j2
@@ -1,2 +1,2 @@
-Thanks @{{ submitter }} for this PR. Please create a new PR using a branch in your fork.
+@{{ submitter }} Please create a new PR using a branch in your fork.
 <!--- boilerplate: fork --->

--- a/templates/issue_missing_data.j2
+++ b/templates/issue_missing_data.j2
@@ -1,4 +1,4 @@
-@{{ submitter }} Greetings! Thanks for taking the time to open this {{ itype }}. In order for the community to handle your {{ itype }} effectively, we need a bit more information. 
+@{{ submitter }}: in order for the community to handle your {{ itype }} effectively, we need a bit more information.
 
 Here are the items we could not find in your description:
 {% for item in missing_sections %}

--- a/templates/notify.j2
+++ b/templates/notify.j2
@@ -1,5 +1,3 @@
-@{{ submitter }}: thank you for submitting this {% if is_pullrequest %}pull-request{% else %}issue{% endif %}!
-
 {% if notify|length > 1 %}
 cc @{{ notify|join(' @') }}
 {% else %}

--- a/templates/thank_submitter.j2
+++ b/templates/thank_submitter.j2
@@ -1,0 +1,4 @@
+Hi @{{ submitter }}, thank you for submitting this {% if is_pullrequest %}pull-request{% else %}issue{% endif %}!
+
+[click here for bot help](https://github.com/ansible/ansibullbot/blob/master/ISSUE_HELP.md)
+<!--- boilerplate: thank_submitter --->


### PR DESCRIPTION
- thank only once:
  - `notify` comment can be used multiple times on the same PR
  - some other templates (but not all) already thanked the submitter
- only thank PR/issue created after Oct 11 2018 (older might have been thanked already)

cc  @mkrizek / @gundalow 