### PR TITLE
Remove `pre_ci_boot` from `shippable.yml`.

### DIFF
--- a/shippable.yml
+++ b/shippable.yml
@@ -3,11 +3,6 @@ python:
   - 2.7
   - 3.7
 build:
-  pre_ci_boot:
-    image_name: drydock/u16pytall
-    image_tag: master
-    pull: false
-    options: --privileged=false --net=bridge
   ci:
    - shippable_retry pip install -Ur test-requirements.txt
 


### PR DESCRIPTION
Tests are now run on newer Shippable nodes which have Python 3.7 available by default.