### PR TITLE
[WIP] Handle changelog fragment

### DIFF
--- a/ansibullbot/triagers/plugins/shipit.py
+++ b/ansibullbot/triagers/plugins/shipit.py
@@ -100,6 +100,9 @@ def get_automerge_facts(issuewrapper, meta):
             if pr_file.deletions:
                 # new exception delete
                 continue
+        elif fnmatch(thisfn, u'changelogs/fragments/*') and pr_file.status == u'added':
+            # ignore new changelog fragment
+            continue
         else:
             # other file modified, pull-request must be checked by an human
             return create_ameta(False, u'automerge !module file(s) test failed')

--- a/ansibullbot/triagers/plugins/shipit.py
+++ b/ansibullbot/triagers/plugins/shipit.py
@@ -240,9 +240,12 @@ def get_shipit_facts(issuewrapper, meta, module_indexer, core_team=[], botnames=
                 if maintainers and (iw.submitter in maintainers):
                     module_utils_files_owned += 1
 
+    maintainers = meta.get(u'component_maintainers', [])
+    maintainers = ModuleIndexer.replace_ansible(maintainers, core_team, bots=botnames)
+
     modules_files_owned = 0
     if not meta[u'is_new_module']:
-        if iw.submitter in meta[u'component_maintainers']:
+        if iw.submitter in maintainers:
             for pr_file in iw.pr_files:
                 if pr_file.filename.startswith(u'lib/ansible/modules/'):
                     modules_files_owned += 1
@@ -261,14 +264,6 @@ def get_shipit_facts(issuewrapper, meta, module_indexer, core_team=[], botnames=
     if meta[u'is_needs_revision'] or meta[u'is_needs_rebase']:
         logging.debug(u'PRs with needs_revision or needs_rebase label do not get shipits')
         return nmeta
-
-    maintainers = meta.get(u'component_maintainers', [])
-    maintainers = \
-        ModuleIndexer.replace_ansible(
-            maintainers,
-            core_team,
-            bots=botnames
-        )
 
     # community is the other maintainers in the same namespace
     community = meta.get(u'component_namespace_maintainers', [])

--- a/ansibullbot/triagers/plugins/shipit.py
+++ b/ansibullbot/triagers/plugins/shipit.py
@@ -242,9 +242,12 @@ def get_shipit_facts(issuewrapper, meta, module_indexer, core_team=[], botnames=
 
     modules_files_owned = 0
     if not meta[u'is_new_module']:
-        for f in iw.files:
-            if f.startswith(u'lib/ansible/modules') and iw.submitter in meta[u'component_maintainers']:
-                modules_files_owned += 1
+        if iw.submitter in meta[u'component_maintainers']:
+            for pr_file in iw.pr_files:
+                if pr_file.filename.startswith(u'lib/ansible/modules/'):
+                    modules_files_owned += 1
+                elif pr_file.filename.startswith(u'changelogs/fragments/') and pr_file.status == u'added':
+                    modules_files_owned += 1
     nmeta[u'owner_pr'] = modules_files_owned + module_utils_files_owned == len(iw.files)
 
     #if not meta['module_match']:


### PR DESCRIPTION
- `changelog/fragment` addition should not prevent automerge
- `changelog/fragment` addition should not prevent `owner_pr` label

@gundalow Should `changelog/fragment` update be allowed (not precised [here](https://docs.ansible.com/ansible/devel/reference_appendices/release_and_maintenance.html?highlight=changelog%20fragment#creating-new-fragments)) ?

unit tests missing.