### PR TITLE
add docker and botmeta validator infra

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -19,3 +19,6 @@
 [submodule "playbooks/roles/yum-cron"]
 	path = playbooks/roles/yum-cron
 	url = https://github.com/samdoran/ansible-role-yum-cron.git
+[submodule "playbooks/roles/geerlingguy.docker"]
+	path = playbooks/roles/geerlingguy.docker
+	url = https://github.com/geerlingguy/ansible-role-docker

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -14,14 +14,14 @@ if [[ $RC != 0 ]]; then
 fi
 
 # BASELINE PACKAGES
-PACKAGES="epel-release ansible git vim-enhanced bind-utils policycoreutils-python"
+PACKAGES="epel-release ansible git vim-enhanced bind-utils policycoreutils-python net-tools lsof"
 for PKG in $PACKAGES; do
     rpm -q $PKG || yum -y install $PKG
 done
 
 # VIMRC
 rm -f /etc/vimrc
-cp /vagrant/playbook/files/centos7.vimrc /etc/vimrc
+cp /vagrant/playbooks/files/centos7.vimrc /etc/vimrc
 
 # PSEUDO ANSIBLE-LOCAL PROVISIONER
 echo "ansibullbot ansible_host=localhost ansible_connection=local" > /tmp/inv.ini
@@ -32,6 +32,11 @@ ansible-playbook \
     -e "ansibullbot_action=install" \
     --skip-tags=botinstance,dns,ssh,ansibullbot_service,ansibullbot_logs \
     setup-ansibullbot.yml
+
+# HACK IN FIREWALL EXCEPTIONS
+firewall-cmd --zone=public --add-port=80/tcp --permanent
+firewall-cmd --reload
+
 SCRIPT
 
 ENV['VAGRANT_DEFAULT_PROVIDER'] = 'virtualbox'

--- a/botmeta_schema_validator/Dockerfile
+++ b/botmeta_schema_validator/Dockerfile
@@ -4,10 +4,12 @@ MAINTAINER James Tanner <tanner.jc@gmail.com>
 ENV PYTHONUNBUFFERED 1
 RUN mkdir -p /opt/server/src
 COPY . /opt/server/src
-WORKDIR /opt/server/src
+RUN rm -rf /opt/server/src/tests
+WORKDIR /opt/server/src/botmeta_schema_validator
 RUN pip install -r requirements.txt
-RUN git clone https://github.com/ansible/ansibullbot ansibullbot.checkout
-RUN ln -s ansibullbot.checkout/ansibullbot ansibullbot
+#RUN git clone https://github.com/ansible/ansibullbot ansibullbot.checkout
+RUN ln -s /opt/server/src/ansibullbot ansibullbot
+#COPY ../ ansibullbot
 EXPOSE 5000
 CMD ["python", "flaskapp.py"]
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,47 @@
+version: '3.3'
+services:
+  rabbit:
+    hostname: rabbit
+    image: rabbitmq:latest
+    environment:
+      - RABBITMQ_DEFAULT_USER=admin
+      - RABBITMQ_DEFAULT_PASS=mypass
+    ports:
+      - "5673:5672"
+    networks:
+      ansibot_nw:
+        ipv4_address: 172.20.0.2
+  schemavalidator:
+    hostname: schemavalidator
+    image: schemavalidator
+    build:
+      context: .
+      dockerfile: botmeta_schema_validator/Dockerfile
+    links:
+      - rabbit
+    depends_on:
+      - rabbit
+    networks:
+      ansibot_nw:
+        ipv4_address: 172.20.0.4
+    environment:
+      PYTHONUNBUFFERED: 1
+      CELERY_BROKER_URL: pyamqp://rabbit:5672
+      CELERY_RESULT_BACKEND: mongodb://mongo:27017
+      CELERY_MONGODB_BACKEND_DATABASE: schemavalidator
+      CELERY_MONGODB_BACKEND_COLLECTION: results
+  database:
+    hostname: mongo
+    image: mongo:latest
+    ports:
+      - "27018:27017"
+    networks:
+      ansibot_nw:
+        ipv4_address: 172.20.0.3
+
+networks:
+  ansibot_nw:
+    driver: bridge
+    ipam:
+      config:
+        - subnet: 172.20.0.0/16

--- a/playbooks/roles/ansibullbot.httpd/handlers/main.yml
+++ b/playbooks/roles/ansibullbot.httpd/handlers/main.yml
@@ -1,0 +1,4 @@
+- name: restart_httpd
+  service:
+    name: httpd
+    state: restarted

--- a/playbooks/roles/ansibullbot.httpd/tasks/main.yml
+++ b/playbooks/roles/ansibullbot.httpd/tasks/main.yml
@@ -1,0 +1,16 @@
+- name: install httpd
+  package:
+    name: httpd
+    state: latest
+  notify: restart_httpd
+
+- name: enable httpd
+  service:
+    name: httpd
+    enabled: yes
+
+- name: copy the proxy config
+  template:
+    src: ansibot.conf
+    dest: /etc/httpd/conf.d/ansibot.conf
+  notify: restart_httpd

--- a/playbooks/roles/ansibullbot.httpd/templates/ansibot.conf
+++ b/playbooks/roles/ansibullbot.httpd/templates/ansibot.conf
@@ -1,0 +1,8 @@
+<VirtualHost *:80>
+    ProxyPreserveHost On
+    ProxyPass /schemavalidator/ http://172.20.0.4:5000/
+    ProxyPassReverse /schemavalidator/ http://172.20.0.4:5000/
+
+    ProxyPass /schemavalidator/static/ http://172.20.0.4:5000/
+    ProxyPassReverse /schemavalidator/static/ http://172.20.0.4:5000/
+</VirtualHost>

--- a/playbooks/setup-ansibullbot.yml
+++ b/playbooks/setup-ansibullbot.yml
@@ -15,6 +15,7 @@
     - repo-epel
     - firewall
     - fail2ban
+    - geerlingguy.docker
     - mongodb
     - ansibullbot
     - yum-cron

--- a/playbooks/setup-ansibullbot.yml
+++ b/playbooks/setup-ansibullbot.yml
@@ -19,3 +19,4 @@
     - mongodb
     - ansibullbot
     - yum-cron
+    - ansibullbot.httpd

--- a/playbooks/update-ansibullbot.yml
+++ b/playbooks/update-ansibullbot.yml
@@ -3,5 +3,7 @@
   become: yes
 
   roles:
+    - geerlingguy.docker
+    - ansibullbot.httpd
     - role: ansibullbot
       ansibullbot_action: update


### PR DESCRIPTION
Adds docker to the machine and a docker-compose that creates a base infra to include the botmeta validator.