### PR TITLE
Fix TypeError: use bytes (Py3 compat)

### DIFF
--- a/ansibullbot/utils/shippable_api.py
+++ b/ansibullbot/utils/shippable_api.py
@@ -4,7 +4,7 @@
 # https://api.shippable.com/projects/573f79d02a8192902e20e34b | jq .
 
 import ansibullbot.constants as C
-from ansibullbot._text_compat import to_text
+from ansibullbot._text_compat import to_text, to_bytes
 
 import datetime
 import gzip
@@ -138,7 +138,7 @@ class ShippableRuns(object):
 
     def _write_cache_file(self, cfile, data):
         with gzip.open(cfile, 'w') as f:
-            f.write(json.dumps(data))
+            f.write(to_bytes(json.dumps(data)))
 
     def _compress_cache_file(self, cfile, gzfile):
         with open(cfile, 'r') as f_in, gzip.open(gzfile, 'w') as f_out:


### PR DESCRIPTION
Fix this exception which occurs with Python 3.7:

    Traceback (most recent call last):
      File "./triage_ansible.py", line 51, in <module>
        main()
      File "./triage_ansible.py", line 47, in main
        AnsibleTriage().start()
      File "ansibullbot/triagers/defaulttriager.py", line 187, in start
        self.run()
      File "ansibullbot/triagers/ansible.py", line 472, in run
        self.process(iw)
      File "ansibullbot/triagers/ansible.py", line 1910, in process
        shippable=self.SR
      File "ansibullbot/triagers/plugins/needs_revision.py", line 149, in get_needs_revision_facts
        ci_date = get_last_shippable_full_run_date(ci_status, shippable)
      File "ansibullbot/triagers/plugins/needs_revision.py", line 666, in get_last_shippable_full_run_date
        rdata = shippable.get_run_data(to_text(runid), usecache=False)
      File "ansibullbot/utils/shippable_api.py", line 232, in get_run_data
        run_data = self._get_url(run_url, usecache=usecache)
      File "ansibullbot/utils/shippable_api.py", line 184, in _get_url
        self._write_cache_file(gzfile, [resp.status_code, jdata])
      File "ansibullbot/utils/shippable_api.py", line 141, in _write_cache_file
        f.write(json.dumps(data))
      File "/usr/lib/python3.7/gzip.py", line 260, in write
        data = memoryview(data)
    TypeError: memoryview: a bytes-like object is required, not 'str'

Manually tested using Python 2.7 and Python 3.7 using this command:

    ./triage_ansible.py --dry-run --pr 48991 --logfile log