### PR TITLE
Treat GitHub's Server Error resp as a Rate Limit

### DIFF
--- a/ansibullbot/wrappers/defaultwrapper.py
+++ b/ansibullbot/wrappers/defaultwrapper.py
@@ -1098,9 +1098,6 @@ class DefaultWrapper(object):
         jdata = json.loads(body)
 
         # need to catch rate limit message here
-        if isinstance(jdata, dict) and u'rate' in jdata[u'message']:
-            raise RateLimitError("rate limited")
-
         if isinstance(jdata, dict):
             logging.error(
                 u'get_reviews | pr_reviews.keys=%s | pr_reviews.len=%s | '
@@ -1108,6 +1105,14 @@ class DefaultWrapper(object):
                 jdata.keys(), len(jdata),
                 hdrs, status,
             )
+
+            is_rate_limited = u'rate' in jdata[u'message']
+            is_server_error = (
+                u'Server Error' == jdata[u'message']
+                or 500 <= status < 600
+            )
+            if is_rate_limited or is_server_error:
+                raise RateLimitError("rate limited")
 
         return jdata
 

--- a/ansibullbot/wrappers/defaultwrapper.py
+++ b/ansibullbot/wrappers/defaultwrapper.py
@@ -1097,7 +1097,6 @@ class DefaultWrapper(object):
         )
         jdata = json.loads(body)
 
-        # need to catch rate limit message here
         if isinstance(jdata, dict):
             logging.error(
                 u'get_reviews | pr_reviews.keys=%s | pr_reviews.len=%s | '
@@ -1111,8 +1110,17 @@ class DefaultWrapper(object):
                 u'Server Error' == jdata[u'message']
                 or 500 <= status < 600
             )
-            if is_rate_limited or is_server_error:
+
+            if is_rate_limited:
                 raise RateLimitError("rate limited")
+
+            if is_server_error:
+                raise RateLimitError("server error")
+
+            raise RateLimitError(
+                "unknown error: GH responded with a dict "
+                "while a list of reviews was expected"
+            )
 
         return jdata
 


### PR DESCRIPTION
This should fix https://sentry.io/red-hat-ansibullbot/ansibullbot/issues/828783387/
and will probably fix https://sentry.io/red-hat-ansibullbot/ansibullbot/issues/828783412/