### PR TITLE
Only warn on missing metadata

### DIFF
--- a/ansibullbot/utils/extractors.py
+++ b/ansibullbot/utils/extractors.py
@@ -604,6 +604,8 @@ class ModuleExtractor(object):
             return {}
         if self.filepath.endswith('.ps2'):
             return {}
+        if self.filepath.endswith('.rst'):
+            return {}
 
         meta = {}
         rawmeta = b''
@@ -632,6 +634,6 @@ class ModuleExtractor(object):
         try:
             meta = ast.literal_eval(to_text(rawmeta))
         except Exception as e:
-            logging.error(e)
+            logging.warning(e)
 
         return meta


### PR DESCRIPTION
```
Sentry APP [6:25 PM]
unexpected EOF while parsing (<unknown>, line 0)
ANSIBULLBOT-3K via AlertToday at 6:24 PM


Sentry APP [7:03 PM]
unexpected EOF while parsing (<unknown>, line 0)
ANSIBULLBOT-3K via AlertToday at 7:03 PM

Sentry APP [7:41 PM]
unexpected EOF while parsing (<unknown>, line 0)
```