### PR TITLE
Use shippable states only

### DIFF
--- a/ansibullbot/triagers/plugins/needs_revision.py
+++ b/ansibullbot/triagers/plugins/needs_revision.py
@@ -146,7 +146,9 @@ def get_needs_revision_facts(triager, issuewrapper, meta, shippable=None):
         ci_stale = True
     else:
         # https://github.com/ansible/ansibullbot/issues/935
-        ci_date = get_last_shippable_full_run_date(ci_status, shippable)
+        shippable_states = [x for x in ci_status
+                            if isinstance(x, dict) and x.get('context') == 'Shippable']
+        ci_date = get_last_shippable_full_run_date(shippable_states, shippable)
 
         # https://github.com/ansible/ansibullbot/issues/458
         if ci_date:

--- a/ansibullbot/utils/moduletools.py
+++ b/ansibullbot/utils/moduletools.py
@@ -513,7 +513,7 @@ class ModuleIndexer(object):
                     pickle_dump((mtime, self.commits[k]), f)
 
     def last_commit_for_file(self, filepath):
-        if filepath in self.commits:
+        if filepath in self.commits and u'hash' in self.commits[filepath][0]:
             return self.commits[filepath][0][u'hash']
 
         # git log --pretty=format:'%H' -1


### PR DESCRIPTION
I noticed the following traceback caused by https://github.com/ansible/ansible/pull/56714:
```
IndexError: list index out of range
  File "triage_ansible.py", line 45, in <module>
    main()
  File "triage_ansible.py", line 41, in main
    AnsibleTriage().start()
  File "ansibullbot/triagers/defaulttriager.py", line 203, in start
    self.loop()
  File "ansibullbot/triagers/defaulttriager.py", line 314, in loop
    self.run()
  File "ansibullbot/triagers/ansible.py", line 470, in run
    self.process(iw)
  File "ansibullbot/triagers/ansible.py", line 1926, in process
    shippable=self.SR
  File "ansibullbot/triagers/plugins/needs_revision.py", line 149, in get_needs_revision_facts
    ci_date = get_last_shippable_full_run_date(ci_status, shippable)
  File "ansibullbot/triagers/plugins/needs_revision.py", line 648, in get_last_shippable_full_run_date
    runids = [get_runid_from_status(x) for x in ci_status]
  File "ansibullbot/triagers/plugins/needs_revision.py", line 723, in get_runid_from_status
    if paths[-2].isdigit():
```

We should filter anything other than shippable states before getting run IDs.