### PR TITLE
Prevent formatting components in comments

### DIFF
--- a/templates/components_banner.j2
+++ b/templates/components_banner.j2
@@ -1,7 +1,7 @@
 Files identified in the description:
 {% if meta['component_matches'] %}
 {% for x in meta['component_matches'] %}
-* {{ '[' + x['repo_filename'] + '](' + 'https://github.com/ansible/ansible/blob/devel/' + x['repo_filename'] + ')'}}
+* {{ '[`' + x['repo_filename'] + '`](' + 'https://github.com/ansible/ansible/blob/devel/' + x['repo_filename'] + ')'}}
 {% endfor %}
 {% else %}
 None


### PR DESCRIPTION
Fixes https://github.com/ansible/ansibullbot/issues/1200

Before:

Files identified in the description:
* [lib/ansible/parsing/vault/__init__.py](https://github.com/ansible/ansible/blob/devel/lib/ansible/parsing/vault/__init__.py)

After:

Files identified in the description:
* [`lib/ansible/parsing/vault/__init__.py`](https://github.com/ansible/ansible/blob/devel/lib/ansible/parsing/vault/__init__.py)