### PR TITLE
Commit comments do not have created_at

### DIFF
--- a/ansibullbot/wrappers/defaultwrapper.py
+++ b/ansibullbot/wrappers/defaultwrapper.py
@@ -218,6 +218,10 @@ class DefaultWrapper(object):
                 if not dd.get(u'created_at') and dd.get('author'):
                     dd[u'created_at'] = dd[u'author'][u'date']
 
+                # commit comments do not have created_at keys
+                if not dd.get(u'created_at') and dd.get('comments'):
+                    dd[u'created_at'] = dd[u'comments'][0][u'created_at']
+
                 # commits do not have actors
                 if not dd.get(u'actor'):
                     dd[u'actor'] = {'login': None}


### PR DESCRIPTION
https://github.com/ansible/ansible/pull/27757
https://github.com/ansible/ansible/commit/9831ab7e8cbb6d07f68e530c6101becbc95598c9

```
KeyError: u'created_at'
  File "triage_ansible.py", line 45, in <module>
    main()
  File "triage_ansible.py", line 41, in main
    AnsibleTriage().start()
  File "ansibullbot/triagers/defaulttriager.py", line 203, in start
    self.loop()
  File "ansibullbot/triagers/defaulttriager.py", line 314, in loop
    self.run()
  File "ansibullbot/triagers/ansible.py", line 466, in run
    self.build_history(iw)
  File "ansibullbot/triagers/ansible.py", line 2065, in build_history
    iw.history
  File "ansibullbot/wrappers/defaultwrapper.py", line 1260, in history
    HistoryWrapper(self, cachedir=self.cachedir, usecache=True)
  File "ansibullbot/wrappers/historywrapper.py", line 146, in __init__
    self.history = self.process()
  File "ansibullbot/wrappers/historywrapper.py", line 677, in process
    events = self.issue.events
  File "ansibullbot/wrappers/defaultwrapper.py", line 201, in events
    self._events = self.get_events()
  File "ansibullbot/wrappers/defaultwrapper.py", line 240, in get_events
    events = sorted(events, key=lambda x: x[u'created_at'])
  File "ansibullbot/wrappers/defaultwrapper.py", line 240, in <lambda>
    events = sorted(events, key=lambda x: x[u'created_at'])
```