### PR TITLE
dict events have ids sometimes

### DIFF
--- a/ansibullbot/wrappers/historywrapper.py
+++ b/ansibullbot/wrappers/historywrapper.py
@@ -707,10 +707,11 @@ class HistoryWrapper(object):
         for ide,event in enumerate(events):
 
             if isinstance(event, dict):
-                event = Event(
-                    event,
-                    id='%s_%s_%s' % (self.issue.repo_full_name, self.issue.number, ide)
-                )
+                if 'id' in event:
+                    thisid = event['id']
+                else:
+                    thisid = '%s_%s_%s' % (self.issue.repo_full_name, self.issue.number, ide)
+                event = Event(event, id=thisid)
 
             cdict = self.get_event_from_cache(event.id, cache)
 


### PR DESCRIPTION
Fixes ...

```
2019-08-29 12:57:22,396 ERROR Uncaught exception
Traceback (most recent call last):
  File "/home/ansibot/ansibullbot/triage_ansible.py", line 45, in <module>
    main()
  File "/home/ansibot/ansibullbot/triage_ansible.py", line 41, in main
    AnsibleTriage(args=sys.argv[1:]).start()
  File "/home/ansibot/ansibullbot/ansibullbot/triagers/defaulttriager.py", line 177, in start
    self.loop()
  File "/home/ansibot/ansibullbot/ansibullbot/triagers/defaulttriager.py", line 288, in loop
    self.run()
  File "/home/ansibot/ansibullbot/ansibullbot/triagers/ansible.py", line 503, in run
    self.process(iw)
  File "/home/ansibot/ansibullbot/ansibullbot/triagers/ansible.py", line 1989, in process
    self.meta.update(needs_info_timeout_facts(iw, self.meta))
  File "/home/ansibot/ansibullbot/ansibullbot/triagers/plugins/needs_info.py", line 184, in needs_info_timeout_facts
    delta = (now - la).days
TypeError: unsupported operand type(s) for -: 'datetime.datetime' and 'NoneType'
```