### PR TITLE
issue_missing_data - correct link

### DIFF
--- a/templates/issue_missing_data.j2
+++ b/templates/issue_missing_data.j2
@@ -7,7 +7,7 @@ Here are the items we could not find in your description:
 
 Please set the description of this {{ itype }} with this template:
 {% if itype == 'issue' %}
-https://raw.githubusercontent.com/ansible/ansible/devel/.github/ISSUE_TEMPLATE.md
+https://raw.githubusercontent.com/ansible/ansible/devel/.github/ISSUE_TEMPLATE/bug_report.md
 {% else %}
 https://raw.githubusercontent.com/ansible/ansible/devel/.github/PULL_REQUEST_TEMPLATE.md
 {% endif %}


### PR DESCRIPTION
Direct people to an issue template which actually includes the headings