### PR TITLE
Use gzip to open log file to avoid memory leak

### DIFF
--- a/scripts/ansibot_receiver.py
+++ b/scripts/ansibot_receiver.py
@@ -3,6 +3,7 @@
 # $ curl -v -X POST --header "Content-Type: application/json" -d@summaries.json 'http://localhost:5001/summaries?user=ansible&repo=ansible'
 
 import glob
+import gzip
 import json
 import subprocess
 
@@ -341,11 +342,9 @@ def logs(issue=None):
                 log_lines = log_lines + f.readlines()
         # consume the compressed logs too if looking for a specific issue
         elif issue and lf.endswith('.gz'):
-            cmd = 'zcat %s' % lf
-            p = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-            so,se = p.communicate()
-            lines = so.split('\n')
-            log_lines = lines + log_lines
+            with gzip.open(lf, 'rb') as zf:
+                file_data = zf.readlines()
+            log_lines.extend(file_data)
 
     # if the caller doesn't want a specific issue, get the tail of the log and all tracebacks
     if not issue:

--- a/scripts/ansibot_receiver.py
+++ b/scripts/ansibot_receiver.py
@@ -5,8 +5,6 @@
 import glob
 import gzip
 import json
-import subprocess
-
 import six
 
 from flask import Flask


### PR DESCRIPTION
Using `Popen.communicate()` with `PIPE` to capture stdout is problematic when the data is large. From the `subprocess` docs:

> **Note** The data read is buffered in memory, so do not use this method if the data size is large or unlimited.

The log files are rather large and it seems that something is not properly cleaning up the data, resulting in a memory leak.

Loading one log file just to see how big it is.
```
>>> file = '/var/log/ansibullbot.log.1.gz'
>>> p = subprocess.Popen('zcat %s' % file, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
>>> so,se = p.communicate()
>>> sys.getsizeof(so)
657176588
```

Monitoring the running process with `pidstat` show `%MEM` and `RSS` steadily increasing.
```
> pidstat -p 15214 -l -r 2
02:32:47 PM   UID       PID  minflt/s  majflt/s     VSZ    RSS   %MEM  Command
02:32:48 PM  1099       668   4104.00      0.00 2925204 2481320  15.44  /usr/bin/python /home/ansibot/ansibullbot/scripts/ansibot_receiver.py
02:32:49 PM  1099       668   1990.00      0.00 2932628 2489208  15.48  /usr/bin/python /home/ansibot/ansibullbot/scripts/ansibot_receiver.py
02:32:50 PM  1099       668   2140.00      0.00 2940052 2497688  15.54  /usr/bin/python /home/ansibot/ansibullbot/scripts/ansibot_receiver.py
02:32:51 PM  1099       668      0.00      0.00 2940052 2497688  15.54  /usr/bin/python /home/ansibot/ansibullbot/scripts/ansibot_receiver.py
02:32:52 PM  1099       668   1898.00      0.00 2947476 2505208  15.58  /usr/bin/python /home/ansibot/ansibullbot/scripts/ansibot_receiver.py
02:32:53 PM  1099       668      0.00      0.00 2947476 2505208  15.58  /usr/bin/python /home/ansibot/ansibullbot/scripts/ansibot_receiver.py
02:32:54 PM  1099       668      0.00      0.00 2947476 2505208  15.58  /usr/bin/python /home/ansibot/ansibullbot/scripts/ansibot_receiver.py
02:32:55 PM  1099       668      0.00      0.00 2947476 2505208  15.58  /usr/bin/python /home/ansibot/ansibullbot/scripts/ansibot_receiver.py
02:32:56 PM  1099       668      0.00      0.00 2947476 2505208  15.58  /usr/bin/python /home/ansibot/ansibullbot/scripts/ansibot_receiver.py
02:32:57 PM  1099       668      0.00      0.00 2947476 2505208  15.58  /usr/bin/python /home/ansibot/ansibullbot/scripts/ansibot_receiver.py
02:32:58 PM  1099       668      0.00      0.00 2947476 2505208  15.58  /usr/bin/python /home/ansibot/ansibullbot/scripts/ansibot_receiver.py
02:32:59 PM  1099       668      0.00      0.00 2947476 2505208  15.58  /usr/bin/python /home/ansibot/ansibullbot/scripts/ansibot_receiver.py
02:33:00 PM  1099       668      0.00      0.00 2947476 2505208  15.58  /usr/bin/python /home/ansibot/ansibullbot/scripts/ansibot_receiver.py
02:33:01 PM  1099       668      0.00      0.00 2947476 2505208  15.58  /usr/bin/python /home/ansibot/ansibullbot/scripts/ansibot_receiver.py
02:33:02 PM  1099       668      0.00      0.00 2947476 2505208  15.58  /usr/bin/python /home/ansibot/ansibullbot/scripts/ansibot_receiver.py
02:33:03 PM  1099       668   2057.00      0.00 2955412 2513360  15.63  /usr/bin/python /home/ansibot/ansibullbot/scripts/ansibot_receiver.py
02:33:04 PM  1099       668   1992.00      0.00 2962836 2521244  15.68  /usr/bin/python /home/ansibot/ansibullbot/scripts/ansibot_receiver.py
02:33:05 PM  1099       668   3939.00      0.00 2977684 2536852  15.78  /usr/bin/python /home/ansibot/ansibullbot/scripts/ansibot_receiver.py
02:33:06 PM  1099       668      0.00      0.00 2977684 2536852  15.78  /usr/bin/python /home/ansibot/ansibullbot/scripts/ansibot_receiver.py
02:33:07 PM  1099       668      0.00      0.00 2977684 2536852  15.78  /usr/bin/python /home/ansibot/ansibullbot/scripts/ansibot_receiver.py
```