### PR TITLE
Don't add component_name if we didn't found one.

### DIFF
--- a/ansibullbot/triagers/plugins/component_matching.py
+++ b/ansibullbot/triagers/plugins/component_matching.py
@@ -183,7 +183,8 @@ def get_component_match_facts(iw, component_matcher, valid_labels):
                             _filenames.append(m.group(1))
                 _filenames = sorted(set(_filenames))
                 expected = sorted(set([x[u'repo_filename'] for x in CM_MATCHES]))
-                if _filenames != expected:
+                # https://github.com/ansible/ansibullbot/issues/1301
+                if expected and _filenames != expected:
                     cmeta[u'needs_component_message'] = True
 
     return cmeta

--- a/templates/components_banner.j2
+++ b/templates/components_banner.j2
@@ -1,5 +1,5 @@
-Files identified in the description:
 {% if meta['component_matches'] %}
+Files identified in the description:
 {% for x in meta['component_matches'] %}
 {% if x['is_collection'] or x['repo_filename'].startswith('collection:') %}
 * {{ '[`' + x['repo_filename']|string + '`](' + x['collection_scm']|string + ')'}}
@@ -8,7 +8,7 @@ Files identified in the description:
 {% endif %}
 {% endfor %}
 {% else %}
-None
+No files were identified in the description
 {% endif %}
 
 If these files are incorrect, please update the `component name` section of the description or use the `!component` bot command.


### PR DESCRIPTION
If the expected list of components found is empty, do nothing.
I nonetheless modified also the template so when no component is found
we write it explicitely instead of return 'None'

Fixes #1301