### PR TITLE
Specify repo to triage now that multiple are listed

### DIFF
--- a/playbooks/group_vars/ansibullbot.yml
+++ b/playbooks/group_vars/ansibullbot.yml
@@ -1,16 +1,4 @@
 ansible_user: centos
-
-ansibullbot_options:
-  - daemonize
-  - daemonize_interval={{ ansibullbot_daemonize_interval }}
-  - debug
-  - force
-  - logfile {{ ansibullbot_log_path }}
-  - resume
-  - skip_no_update
-  - skip_no_update_timeout
-  - verbose
-
 ansibullbot_receiver_enabled: true
 
 ansibullbot_github_password: !vault |

--- a/playbooks/host_vars/ansibullbot.eng.ansible.com.yml
+++ b/playbooks/host_vars/ansibullbot.eng.ansible.com.yml
@@ -1,2 +1,13 @@
-ansibullbot_sentry_server_name: orangemontana
+ansibullbot_sentry_server_name: ansibullbot
 ansibullbot_fqdn: ansibullbot.eng.ansible.com
+ansibullbot_options:
+  - daemonize
+  - daemonize_interval={{ ansibullbot_daemonize_interval }}
+  - debug
+  - force
+  - logfile {{ ansibullbot_log_path }}
+  - resume
+  - repo ansible/ansible
+  - skip_no_update
+  - skip_no_update_timeout
+  - verbose


### PR DESCRIPTION
The bot will triage all repos in the `REPOS` constant. Now that we have added another repo to that list, we need to limit each bot instance to target only the relevant repo.