### PR TITLE
Skip supershipit test

### DIFF
--- a/tests/component/test_supershipit.py
+++ b/tests/component/test_supershipit.py
@@ -2,6 +2,7 @@ import glob
 import json
 import os
 
+import pytest
 import yaml
 
 from tests.utils.componentmocks import BotMockManager
@@ -11,7 +12,7 @@ from ansibullbot.triagers.ansible import AnsibleTriage
 
 
 class TestSuperShipit:
-
+    @pytest.mark.skip(reason="automerge is disabled now and this is not really an unit test.")
     def test_supershipit(self, *args, **kwargs):
         with BotMockManager() as mm:
             botmeta = {

--- a/tests/component/test_supershipit.py
+++ b/tests/component/test_supershipit.py
@@ -12,6 +12,11 @@ from ansibullbot.triagers.ansible import AnsibleTriage
 
 
 class TestSuperShipit:
+    # FIXME a hack to create the log file which **several** of other tests rely on
+    def test_presupershipit(self):
+        with BotMockManager() as mm:
+            os.system('touch %s' % os.path.join(mm.cachedir, 'bot.log'))
+
     @pytest.mark.skip(reason="automerge is disabled now and this is not really an unit test.")
     def test_supershipit(self, *args, **kwargs):
         with BotMockManager() as mm:


### PR DESCRIPTION
1. automerge is disabled now
2. this test takes too long
3. it is not really an unit test