### PR TITLE
Apply 'docsite_pr' Label

### DIFF
--- a/ansibullbot/triagers/ansible.py
+++ b/ansibullbot/triagers/ansible.py
@@ -1265,16 +1265,21 @@ class AnsibleTriage(DefaultTriager):
                 if label_name in iw.labels:
                     actions.unlabel.append(label_name)
 
-        # docs_only?
-        # https://github.com/ansible/ansibullbot/issues/1047
+        # docs_only, docsite_pr?
+        #   docs_only - https://github.com/ansible/ansibullbot/issues/1047
+        #   docsite_pr - https://github.com/ansible/ansibullbot/issues/1193
         if iw.is_pullrequest():
-            label_name = 'docs_only'
-            if self.meta['is_docs_only']:
-                if label_name not in iw.labels:
-                    actions.newlabel.append(label_name)
-            else:
-                if label_name in iw.labels:
-                    actions.unlabel.append(label_name)
+            label_meta = {
+                'docs_only': 'is_docs_only',
+                'docsite_pr': 'is_docsite_pr'
+            }
+            for label_name, meta_key in label_meta.items():
+                if self.meta[meta_key]:
+                    if label_name not in iw.labels:
+                        actions.newlabel.append(label_name)
+                else:
+                    if label_name in iw.labels:
+                        actions.unlabel.append(label_name)
 
         if iw.is_pullrequest():
 

--- a/tests/fixtures/docs_info/6_issue.yml
+++ b/tests/fixtures/docs_info/6_issue.yml
@@ -1,0 +1,23 @@
+html_url: https://github.com/ansible/ansible/pull/21313
+number: 21313
+github_repo: ansible
+submitter: sommersoft
+created_at: 2016-02-18T17:37:01Z
+title: Test
+body: |
+    test docs_info
+events:
+    - event: committed
+      created_at: 2017-12-10T17:24:02Z
+      id: 1
+      actor:
+        login: web-flow
+        name: GitHub
+      files:
+        - filename: docs/docsite/index.rst
+          status: modified
+          patch: |
+            @@ -2,2 +2,2 @@
+            -   index
+            +   api
+          src_filepath: tests/fixtures/docs_info/files/docsite_index.rst

--- a/tests/unit/triagers/plugins/test_docs_info.py
+++ b/tests/unit/triagers/plugins/test_docs_info.py
@@ -34,6 +34,11 @@ datafiles = (
         'path': 'tests/fixtures/docs_info/3_issue.yml',
         'expected_result': {'is_docs_only': False}
     },
+    {
+        'id': 'docsite_pr: Edited On GitHub',
+        'path': 'tests/fixtures/docs_info/6_issue.yml',
+        'expected_result': {'is_docsite_pr': True}
+    },
 )
 
 def datafile_id(datafile):

--- a/tests/utils/issue_mock.py
+++ b/tests/utils/issue_mock.py
@@ -8,14 +8,28 @@ class ActorMock:
 
 
 class CommitterMock:
-    def __init__(self, date=None, login=None):
+    def __init__(self, date=None, login=None, name=None, email=None):
         self.date = date
         self.login = login
+        self.name = name
+        self.email = email
 
 
 class CommitBottomMock:
-    def __init__(self, committer_date=None, committer_login=None, message=""):
-        self.committer = CommitterMock(date=committer_date, login=committer_login)
+    def __init__(
+        self,
+        committer_date=None,
+        committer_login=None,
+        committer_name=None,
+        committer_email=None,
+        message=""
+    ):
+        self.committer = CommitterMock(
+            date=committer_date,
+            login=committer_login,
+            name=committer_name,
+            email=committer_email
+        )
         self.message = message
 
 
@@ -70,7 +84,8 @@ class IssueMock:
                 continue
             commit = CommitMock(
                 committer_date=x['created_at'],
-                committer_login=x['actor']['login']
+                committer_login=x['actor']['login'],
+                committer_name=x.get('actor', {}).get('name', '')
             )
             for file in x.get('files', []):
                 cfile = CommitFileMock(


### PR DESCRIPTION
Addresses item two for #1193.

This will apply the `docsite_pr` label to pull requests that have been edited on GitHub, using the "Edit On GitHub" feature. Commits made via this feature carry a couple specific metadata items (see attachment).

I got lucky and there was an open PR on `ansible/ansible` that used this feature:
```shell
$ ./triage_ansible.py --dry-run --verbose --pr 74006 --logfile ../ansibot_log/log.txt --ignore_galaxy
2021-03-24 17:46:45,070 INFO 2938 ansible.py:__init__:225 starting bot
....
2021-03-24 17:46:57,657 INFO 2938 ansible.py:run:506 url: https://github.com/ansible/ansible/pull/74006
2021-03-24 17:46:57,657 INFO 2938 ansible.py:run:507 title: docs(#73995): fix broken link in doc
2021-03-24 17:46:57,657 INFO 2938 ansible.py:run:510 component[f]: lib/ansible/modules/user.py
2021-03-24 17:46:57,657 INFO 2938 ansible.py:run:523 needs_revision
{'cancel_ci': False,
 'cancel_ci_branch': False,
 'close': False,
 'close_migrated': False,
 'comments': [],
 'merge': False,
 'newlabel': ['docsite_pr', 'needs_ci', 'needs_revision'],
 'open': False,
 'rebuild': False,
 'rebuild_failed': False,
 'uncomment': [],
 'unlabel': ['core_review']}
Dry-run specified, skipping execution of actions
2021-03-24 17:46:57,657 INFO 2938 ansible.py:run:540 finished triage for https://github.com/ansible/ansible/pull/74006 in 9.247569s
2021-03-24 17:46:57,657 INFO 2938 ansible.py:run:544 triaged 1 issues in 9.982991 seconds
2021-03-24 17:46:57,657 INFO 2938 defaulttriager.py:start:148 stopping bot
```

_Full run log and GitHub API response:_ [docsite_pr_example.txt](https://github.com/ansible/ansibullbot/files/6200980/docsite_pr_example.txt)

Tagging @acozine
