### PR TITLE
plugins/backports: consider main and master branches like devel

### DIFF
--- a/ansibullbot/triagers/plugins/backports.py
+++ b/ansibullbot/triagers/plugins/backports.py
@@ -9,7 +9,7 @@ def get_backport_facts(issuewrapper):
     if not iw.is_pullrequest():
         return bfacts
 
-    if iw.pullrequest.base.ref != 'devel':
+    if iw.pullrequest.base.ref not in ['devel', 'main', 'master']:
         bfacts['is_backport'] = True
         bfacts['base_ref'] = iw.pullrequest.base.ref
 


### PR DESCRIPTION
While ansible/ansible has specifically "devel", the default branch for collections can be expected to be master or main.