### PR TITLE
triagers/ansible: un-hardcode ansible_core_team

### DIFF
--- a/ansibullbot/constants.py
+++ b/ansibullbot/constants.py
@@ -268,6 +268,16 @@ DEFAULT_GITHUB_REPOS = get_config(
     value_type='list'
 )
 
+# The maintainer teams including the organization where the team is located
+DEFAULT_GITHUB_MAINTAINERS = get_config(
+    p,
+    DEFAULTS,
+    'github_maintainers',
+    '%s_GITHUB_MAINTAINERS' % PROG_NAME.upper(),
+    ['ansible/ansible-commit', 'ansible/ansible-community'],
+    value_type='list'
+)
+
 DEFAULT_CI_PROVIDER = get_config(
     p,
     DEFAULTS,

--- a/ansibullbot/triagers/ansible.py
+++ b/ansibullbot/triagers/ansible.py
@@ -134,17 +134,6 @@ class AnsibleTriage(DefaultTriager):
 
         self.ci = None
         self.ci_class = ci_class
-        self._ansible_core_team = None
-
-    @property
-    def ansible_core_team(self):
-        if self._ansible_core_team is None:
-            teams = [
-                'ansible-commit',
-                'ansible-community',
-            ]
-            self._ansible_core_team = self.ghw.get_members('ansible', teams)
-        return [x for x in self._ansible_core_team if x not in C.DEFAULT_BOT_NAMES]
 
     def load_botmeta(self, gitrepo):
         if self.args.botmetafile is not None:
@@ -1320,7 +1309,7 @@ class AnsibleTriage(DefaultTriager):
                 iw,
                 self.meta,
                 self.ci,
-                self.ansible_core_team,
+                self.maintainer_team,
                 C.DEFAULT_BOT_NAMES,
             )
         )
@@ -1356,13 +1345,13 @@ class AnsibleTriage(DefaultTriager):
         self.meta.update(
             get_shipit_facts(
                 iw, self.meta, self.botmeta['files'],
-                core_team=self.ansible_core_team, botnames=C.DEFAULT_BOT_NAMES,
+                maintainer_team=self.maintainer_team, botnames=C.DEFAULT_BOT_NAMES,
             )
         )
         self.meta.update(get_review_facts(iw, self.meta))
 
         # bot_status needed?
-        self.meta.update(get_bot_status_facts(iw, self.module_indexer.all_maintainers, core_team=self.ansible_core_team, bot_names=C.DEFAULT_BOT_NAMES))
+        self.meta.update(get_bot_status_facts(iw, self.module_indexer.all_maintainers, maintainer_team=self.maintainer_team, bot_names=C.DEFAULT_BOT_NAMES))
 
         # who is this waiting on?
         wo = 'maintainer'
@@ -1383,7 +1372,7 @@ class AnsibleTriage(DefaultTriager):
             get_label_command_facts(
                 iw,
                 self.module_indexer.all_maintainers,
-                core_team=self.ansible_core_team,
+                maintainer_team=self.maintainer_team,
                 valid_labels=valid_labels
             )
         )
@@ -1393,7 +1382,7 @@ class AnsibleTriage(DefaultTriager):
             get_waffling_overrides(
                 iw,
                 self.module_indexer.all_maintainers,
-                core_team=self.ansible_core_team,
+                maintainer_team=self.maintainer_team,
             )
         )
 
@@ -1416,7 +1405,7 @@ class AnsibleTriage(DefaultTriager):
             get_rebuild_merge_facts(
                 iw,
                 self.meta,
-                self.ansible_core_team,
+                self.maintainer_team,
                 self.ci,
             )
         )

--- a/ansibullbot/triagers/defaulttriager.py
+++ b/ansibullbot/triagers/defaulttriager.py
@@ -118,6 +118,20 @@ class DefaultTriager:
             server=C.DEFAULT_GITHUB_URL
         )
 
+        self._maintainer_team = None
+
+    @property
+    def maintainer_team(self):
+        # Note: this assumes that the token used by the bot has access to check
+        # team privileges across potentially more than one organization
+        if self._maintainer_team is None:
+            self._maintainer_team = []
+            teams = C.DEFAULT_GITHUB_MAINTAINERS
+            for team in teams:
+                _org, _team = team.split('/')
+                self._maintainer_team.extend(self.ghw.get_members(_org, _team))
+        return list(set(sorted([x for x in self._maintainer_team if x not in C.DEFAULT_BOT_NAMES])))
+
     @classmethod
     def create_parser(cls):
         parser = argparse.ArgumentParser()

--- a/ansibullbot/triagers/defaulttriager.py
+++ b/ansibullbot/triagers/defaulttriager.py
@@ -130,7 +130,7 @@ class DefaultTriager:
             for team in teams:
                 _org, _team = team.split('/')
                 self._maintainer_team.extend(self.ghw.get_members(_org, _team))
-        return list(set(sorted([x for x in self._maintainer_team if x not in C.DEFAULT_BOT_NAMES])))
+        return sorted(set(self._maintainer_team).difference(C.DEFAULT_BOT_NAMES)))
 
     @classmethod
     def create_parser(cls):

--- a/ansibullbot/triagers/defaulttriager.py
+++ b/ansibullbot/triagers/defaulttriager.py
@@ -130,7 +130,7 @@ class DefaultTriager:
             for team in teams:
                 _org, _team = team.split('/')
                 self._maintainer_team.extend(self.ghw.get_members(_org, _team))
-        return sorted(set(self._maintainer_team).difference(C.DEFAULT_BOT_NAMES)))
+        return sorted(set(self._maintainer_team).difference(C.DEFAULT_BOT_NAMES))
 
     @classmethod
     def create_parser(cls):

--- a/ansibullbot/triagers/plugins/botstatus.py
+++ b/ansibullbot/triagers/plugins/botstatus.py
@@ -1,4 +1,4 @@
-def get_bot_status_facts(issuewrapper, all_maintainers, core_team=[], bot_names=[]):
+def get_bot_status_facts(issuewrapper, all_maintainers, maintainer_team=[], bot_names=[]):
     iw = issuewrapper
     bs = False
     for ev in iw.history.history:
@@ -6,7 +6,7 @@ def get_bot_status_facts(issuewrapper, all_maintainers, core_team=[], bot_names=
             continue
         if 'bot_status' in ev['body']:
             if ev['actor'] not in bot_names:
-                if ev['actor'] in core_team or \
+                if ev['actor'] in maintainer_team or \
                         ev['actor'] == iw.submitter or \
                         ev['actor'] in all_maintainers:
                     bs = True

--- a/ansibullbot/triagers/plugins/ci_rebuild.py
+++ b/ansibullbot/triagers/plugins/ci_rebuild.py
@@ -58,7 +58,7 @@ def _get_last_command(iw, command, username):
 
 
 # https://github.com/ansible/ansibullbot/issues/640
-def get_rebuild_merge_facts(iw, meta, core_team, ci):
+def get_rebuild_merge_facts(iw, meta, maintainer_team, ci):
     rbmerge_meta = {
         'needs_rebuild': meta.get('needs_rebuild', False),
         'needs_rebuild_all': meta.get('needs_rebuild_all', False),
@@ -77,7 +77,7 @@ def get_rebuild_merge_facts(iw, meta, core_team, ci):
     if meta['is_needs_rebase']:
         return rbmerge_meta
 
-    last_command = _get_last_command(iw, 'rebuild_merge', core_team)
+    last_command = _get_last_command(iw, 'rebuild_merge', maintainer_team)
 
     if last_command is None:
         return rbmerge_meta

--- a/ansibullbot/triagers/plugins/label_commands.py
+++ b/ansibullbot/triagers/plugins/label_commands.py
@@ -1,4 +1,4 @@
-def get_label_command_facts(issuewrapper, all_maintainers, core_team=[], valid_labels=[]):
+def get_label_command_facts(issuewrapper, all_maintainers, maintainer_team=[], valid_labels=[]):
     add_labels = []
     del_labels = []
 
@@ -41,7 +41,7 @@ def get_label_command_facts(issuewrapper, all_maintainers, core_team=[], valid_l
     whitelist += [x for x in valid_labels if x.startswith('m:')]
 
     iw = issuewrapper
-    maintainers = [x for x in core_team]
+    maintainers = [x for x in maintainer_team]
     maintainers += all_maintainers
     maintainers = sorted(set(maintainers))
 
@@ -91,11 +91,11 @@ def get_label_command_facts(issuewrapper, all_maintainers, core_team=[], valid_l
     return fact
 
 
-def get_waffling_overrides(issuewrapper, all_maintainers, core_team=[]):
+def get_waffling_overrides(issuewrapper, all_maintainers, maintainer_team=[]):
     overrides = []
 
     iw = issuewrapper
-    maintainers = [x for x in core_team]
+    maintainers = [x for x in maintainer_team]
     maintainers += all_maintainers
     maintainers = sorted(set(maintainers))
 

--- a/ansibullbot/triagers/plugins/needs_revision.py
+++ b/ansibullbot/triagers/plugins/needs_revision.py
@@ -11,7 +11,7 @@ from ansibullbot.utils.timetools import strip_time_safely
 CI_STALE_DAYS = 7
 
 
-def get_needs_revision_facts(iw, meta, ci, core_team=None, botnames=None):
+def get_needs_revision_facts(iw, meta, ci, maintainer_team=None, botnames=None):
     # Thanks @adityacs for this PR. This PR requires revisions, either
     # because it fails to build or by reviewer request. Please make the
     # suggested revisions. When you are done, please comment with text
@@ -19,8 +19,8 @@ def get_needs_revision_facts(iw, meta, ci, core_team=None, botnames=None):
 
     # a "dirty" mergeable_state can exist with "successfull" ci_state.
 
-    if core_team is None:
-        core_team = []
+    if maintainer_team is None:
+        maintainer_team = []
     if botnames is None:
         botnames = []
 
@@ -80,7 +80,7 @@ def get_needs_revision_facts(iw, meta, ci, core_team=None, botnames=None):
     bpcs = iw.history.get_boilerplate_comments()
     bpcs = [x[0] for x in bpcs]
 
-    maintainers = [x for x in core_team if x not in botnames]
+    maintainers = [x for x in maintainer_team if x not in botnames]
 
     maintainers += meta.get('component_maintainers', [])
 

--- a/ansibullbot/triagers/plugins/shipit.py
+++ b/ansibullbot/triagers/plugins/shipit.py
@@ -219,7 +219,7 @@ def get_review_facts(issuewrapper, meta):
     return rfacts
 
 
-def get_shipit_facts(issuewrapper, inmeta, botmeta_files, core_team=[], botnames=[]):
+def get_shipit_facts(issuewrapper, inmeta, botmeta_files, maintainer_team=[], botnames=[]):
     """ Count shipits by maintainers/community/other """
 
     # supershipit - maintainers with isolated commit access
@@ -308,12 +308,12 @@ def get_shipit_facts(issuewrapper, inmeta, botmeta_files, core_team=[], botnames
             supershipiteers_byuser[ss].append(cm['repo_filename'])
 
     maintainers = meta.get('component_maintainers', [])
-    maintainers = replace_ansible(maintainers, core_team, bots=botnames)
+    maintainers = replace_ansible(maintainers, maintainer_team, bots=botnames)
 
     # community is the other maintainers in the same namespace
     community = meta.get('component_namespace_maintainers', [])
     community = [x for x in community if x != 'ansible' and
-                 x not in core_team and
+                 x not in maintainer_team and
                  x != 'DEPRECATED']
 
     # shipit tallies
@@ -359,7 +359,7 @@ def get_shipit_facts(issuewrapper, inmeta, botmeta_files, core_team=[], botnames
         # historical shipits (keep track of all of them, even if reset)
         shipits_historical.add(actor)
 
-        if actor in core_team and is_rebuild_merge(body):
+        if actor in maintainer_team and is_rebuild_merge(body):
             rebuild_merge = True
             logging.info('%s shipit [rebuild_merge]' % actor)
         else:
@@ -370,7 +370,7 @@ def get_shipit_facts(issuewrapper, inmeta, botmeta_files, core_team=[], botnames
             supershipiteers_voted.add(actor)
 
         # ansible shipits
-        if actor in core_team:
+        if actor in maintainer_team:
             if actor not in shipit_actors:
                 ansible_shipits += 1
                 shipit_actors.append(actor)
@@ -398,7 +398,7 @@ def get_shipit_facts(issuewrapper, inmeta, botmeta_files, core_team=[], botnames
         continue
 
     # submitters should count if they are core team/maintainers/community
-    if iw.submitter in core_team:
+    if iw.submitter in maintainer_team:
         if iw.submitter not in shipit_actors:
             ansible_shipits += 1
             shipit_actors.append(iw.submitter)

--- a/examples/ansibullbot.cfg
+++ b/examples/ansibullbot.cfg
@@ -1,7 +1,8 @@
 [defaults]
-github_username=FOO  # required
-github_token=XXXXXXX # either token or password is required,
-github_password=BAR  # usage of a token is recommended
+github_username=FOO                                # required
+github_token=XXXXXXX                               # either token or password is required,
+github_password=BAR                                # usage of a token is recommended
+github_maintainers=org/team,anotherorg/anotherteam # required
 ci_provider=azp
 
 [azp]

--- a/tests/unit/triagers/plugins/test_shipit.py
+++ b/tests/unit/triagers/plugins/test_shipit.py
@@ -229,7 +229,7 @@ class TestSuperShipit(unittest.TestCase):
                 {'repo_filename': 'foo', 'supershipit': ['jane', 'doe']}
             ]
         }
-        sfacts = get_shipit_facts(IW, meta, {}, core_team=['coreperson'])
+        sfacts = get_shipit_facts(IW, meta, {}, maintainer_team=['coreperson'])
         assert not sfacts['supershipit']
         assert not sfacts['shipit']
         assert not sfacts['supershipit']
@@ -388,8 +388,8 @@ class TestShipitRebuildMerge(unittest.TestCase):
                 {'repo_filename': 'foo', 'maintainers': ['jane', 'doe']}
             ]
         }
-        core_team = ['x']
-        sfacts = get_shipit_facts(IW, meta, {}, core_team=core_team)
+        maintainer_team = ['x']
+        sfacts = get_shipit_facts(IW, meta, {}, maintainer_team=maintainer_team)
 
         assert sfacts['shipit']
         assert not sfacts['supershipit']
@@ -418,8 +418,8 @@ class TestShipitRebuildMerge(unittest.TestCase):
                 {'repo_filename': 'foo', 'maintainers': ['jane', 'doe']}
             ]
         }
-        core_team = ['x']
-        sfacts = get_shipit_facts(IW, meta, {}, core_team=core_team)
+        maintainer_team = ['x']
+        sfacts = get_shipit_facts(IW, meta, {}, maintainer_team=maintainer_team)
 
         assert not sfacts['shipit']
         assert not sfacts['supershipit']
@@ -458,7 +458,7 @@ class TestShipitFacts(unittest.TestCase):
             _meta['component_maintainers'] = []
             _meta['component_namespace_maintainers'] = ['LinusU', 'mscherer']
 
-            facts = get_shipit_facts(iw, _meta, {}, core_team=['bcoca'], botnames=['ansibot'])
+            facts = get_shipit_facts(iw, _meta, {}, maintainer_team=['bcoca'], botnames=['ansibot'])
 
             self.assertEqual(iw.submitter, 'mscherer')
             self.assertEqual(['LinusU', 'mscherer'], facts['community_usernames'])
@@ -468,7 +468,7 @@ class TestShipitFacts(unittest.TestCase):
             self.assertEqual(facts['shipit_count_community'], 1)   # LinusU, mscherer
             self.assertFalse(facts['shipit'])
 
-    def test_submitter_is_core_team_and_maintainer(self):
+    def test_submitter_is_maintainer_team_and_maintainer(self):
         """
         Submitter is a namespace maintainer *and* a core team member: approval
         must be automatically added
@@ -481,7 +481,7 @@ class TestShipitFacts(unittest.TestCase):
             _meta['component_maintainers'] = []
             _meta['component_namespace_maintainers'] = ['LinusU']
 
-            facts = get_shipit_facts(iw, _meta, {}, core_team=['bcoca', 'mscherer'], botnames=['ansibot'])
+            facts = get_shipit_facts(iw, _meta, {}, maintainer_team=['bcoca', 'mscherer'], botnames=['ansibot'])
 
             self.assertEqual(iw.submitter, 'mscherer')
             self.assertEqual(['LinusU'], facts['community_usernames'])
@@ -495,7 +495,7 @@ class TestShipitFacts(unittest.TestCase):
         datafile = 'tests/fixtures/shipit/1_issue.yml'
         statusfile = 'tests/fixtures/shipit/1_prstatus.json'
         with get_issue(datafile, statusfile) as iw:
-            facts = get_shipit_facts(iw, meta, {}, core_team=['bcoca', 'mscherer'], botnames=['ansibot'])
+            facts = get_shipit_facts(iw, meta, {}, maintainer_team=['bcoca', 'mscherer'], botnames=['ansibot'])
 
             self.assertEqual(iw.submitter, 'mscherer')
             self.assertFalse(facts['community_usernames'])
@@ -581,7 +581,7 @@ class TestOwnerPR(unittest.TestCase):
             meta = self.meta.copy()
             iw._commits = []
             meta.update(get_component_match_facts(iw, CM, []))
-            facts = get_shipit_facts(iw, meta, botmeta_files, core_team=['bcoca', 'mscherer'], botnames=['ansibot'])
+            facts = get_shipit_facts(iw, meta, botmeta_files, maintainer_team=['bcoca', 'mscherer'], botnames=['ansibot'])
 
             self.assertEqual(iw.submitter, 'ElsA')
             self.assertTrue(facts['owner_pr'])
@@ -613,7 +613,7 @@ class TestOwnerPR(unittest.TestCase):
             iw.gitrepo.files.append('lib/ansible/modules/foo/bar.py')
 
             meta.update(get_component_match_facts(iw, CM, []))
-            facts = get_shipit_facts(iw, meta, botmeta_files, core_team=['bcoca'], botnames=['ansibot'])
+            facts = get_shipit_facts(iw, meta, botmeta_files, maintainer_team=['bcoca'], botnames=['ansibot'])
 
         self.assertEqual(iw.submitter, 'mscherer')
         self.assertTrue(facts['owner_pr'])
@@ -645,7 +645,7 @@ class TestOwnerPR(unittest.TestCase):
             iw.gitrepo = GitRepoWrapperMock()
 
             meta.update(get_component_match_facts(iw, CM, []))
-            facts = get_shipit_facts(iw, meta, botmeta_files, core_team=['bcoca'], botnames=['ansibot'])
+            facts = get_shipit_facts(iw, meta, botmeta_files, maintainer_team=['bcoca'], botnames=['ansibot'])
 
         self.assertEqual(iw.submitter, 'mscherer')
         self.assertFalse(facts['owner_pr'])
@@ -694,7 +694,7 @@ class TestOwnerPR(unittest.TestCase):
         meta = self.meta.copy()
         iw._commits = []
         meta.update(get_component_match_facts(iw, CM, []))
-        facts = get_shipit_facts(iw, meta, botmeta_files, core_team=['bcoca', 'mscherer'], botnames=['ansibot'])
+        facts = get_shipit_facts(iw, meta, botmeta_files, maintainer_team=['bcoca', 'mscherer'], botnames=['ansibot'])
         shutil.rmtree(cachedir)
 
         self.assertEqual(iw.submitter, 'ElsA')
@@ -744,7 +744,7 @@ class TestOwnerPR(unittest.TestCase):
 
             iw._commits = []
             meta.update(get_component_match_facts(iw, CM, []))
-            facts = get_shipit_facts(iw, meta, botmeta_files, core_team=['bcoca', 'mscherer'], botnames=['ansibot'])
+            facts = get_shipit_facts(iw, meta, botmeta_files, maintainer_team=['bcoca', 'mscherer'], botnames=['ansibot'])
 
         self.assertEqual(iw.submitter, 'mscherer')
         self.assertFalse(facts['owner_pr'])
@@ -790,7 +790,7 @@ class TestOwnerPR(unittest.TestCase):
                 MockFile('lib/ansible/module_utils/baz/bar.py')
             ]
             meta.update(get_component_match_facts(iw, CM, []))
-            facts = get_shipit_facts(iw, meta, botmeta_files, core_team=['bcoca'], botnames=['ansibot'])
+            facts = get_shipit_facts(iw, meta, botmeta_files, maintainer_team=['bcoca'], botnames=['ansibot'])
 
         self.assertEqual(iw.submitter, 'mscherer')
         self.assertFalse(facts['owner_pr'])
@@ -827,7 +827,7 @@ class TestOwnerPR(unittest.TestCase):
             meta = self.meta.copy()
             iw._commits = []
             meta.update(get_component_match_facts(iw, CM, []))
-            facts = get_shipit_facts(iw, meta, botmeta_files, core_team=['bcoca', 'mscherer'], botnames=['ansibot'])
+            facts = get_shipit_facts(iw, meta, botmeta_files, maintainer_team=['bcoca', 'mscherer'], botnames=['ansibot'])
 
             self.assertEqual(iw.submitter, 'ElsA')
             self.assertTrue(facts['owner_pr'])
@@ -872,7 +872,7 @@ class TestReviewFacts(unittest.TestCase):
             meta = self.meta.copy()
             iw._commits = []
             meta.update(get_component_match_facts(iw, CM, []))
-            meta.update(get_shipit_facts(iw, meta, botmeta_files, core_team=['bcoca'], botnames=['ansibot']))
+            meta.update(get_shipit_facts(iw, meta, botmeta_files, maintainer_team=['bcoca'], botnames=['ansibot']))
             facts = get_review_facts(iw, meta)
 
         self.assertTrue(facts['community_review'])


### PR DESCRIPTION
Maintainers and committers may be different across different
repositories. As such, we can't hardcode the organization name "ansible"
or the teams so we're pulling it back into a configuration parameter instead.

Since the maintainers are not exclusively ansible core maintainers,
we're also renaming the property to something a bit more generic.