### PR TITLE
Set timout on fetch in Azure Pipelines to prevent indefinite hanging

### DIFF
--- a/ansibullbot/ci/azp.py
+++ b/ansibullbot/ci/azp.py
@@ -102,7 +102,7 @@ class AzurePipelinesCI(BaseCI):
             cache_file = os.path.join(self._cachedir, u'timeline_%s.pickle' % self.build_id)
 
             url = TIMELINE_URL_FMT % self.build_id
-            resp = fetch(url)
+            resp = fetch(url, timeout=TIMEOUT)
             if resp is None:
                 raise Exception('Unable to GET %s' % url)
 
@@ -180,7 +180,7 @@ class AzurePipelinesCI(BaseCI):
                     logging.info('fetching artifacts: stale, no previous data')
 
                 url = ARTIFACTS_URL_FMT % self.build_id
-                resp = fetch(url)
+                resp = fetch(url, timeout=TIMEOUT)
                 if resp is None:
                     raise Exception('Unable to GET %s' % url)
 
@@ -213,7 +213,7 @@ class AzurePipelinesCI(BaseCI):
             else:
                 logging.info('fetching artifacts: stale, no previous data')
 
-            resp = fetch(url, stream=True)
+            resp = fetch(url, timeout=TIMEOUT, stream=True)
             if resp is None:
                 raise Exception('Unable to GET %s' % url)
 


### PR DESCRIPTION
This adds a `timeout` parameter to the `fetch()` calls in `azp.py` that do not have it. Only the change on line 105 is needed to fix the issue, I believe, but adding it other places I don't think will hurt unless the default value of 5 seconds is too low.

Fixes #1585.